### PR TITLE
fix: Updated cli to look in @patternfly/patternfly-doc-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Patternfly documentation core contains the base packages needed to build and rel
 
 Using this package for your documentation is accomplished in just a few simple steps:
 
-1. Run `npx patternfly-doc-core@latest setup` from the root of your repo. This will:
+1. Run `npx @patternfly/patternfly-doc-core@latest setup` from the root of your repo. This will:
    - add the documentation core as a dependency in your package
    - add the relevant scripts for using the documentation core to your package scripts
    - create the configuration file for customizing the documentation core

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -24,7 +24,7 @@ function updateContent(program: Command) {
 }
 
 const astroRoot = import.meta
-  .resolve('patternfly-doc-core')
+  .resolve('@patternfly/patternfly-doc-core')
   .replace('dist/cli/cli.js', '')
   .replace('file://', '')
 const currentDir = process.cwd()


### PR DESCRIPTION
Updated code for the cli to look in the correct package @patternfly/patternfly-doc-core now that is where we are releasing for npm.

