### PR TITLE
feat: Created PropsTable component structure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nanostores/react": "^0.8.0",
         "@patternfly/patternfly": "^6.0.0",
         "@patternfly/react-core": "^6.0.0",
+        "@patternfly/react-table": "^6.0.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "astro": "^5.4.1",
@@ -3444,17 +3445,16 @@
       "license": "MIT"
     },
     "node_modules/@patternfly/react-core": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.0.0.tgz",
-      "integrity": "sha512-UKFj9+YzBY+FfEDsLONgOM4N0e8SPV/27/UzNRiJ0gpgqbw2POuXwLpjGSRTTIUuCaLaGGM5PeTSj7mMB73ykw==",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.1.0.tgz",
+      "integrity": "sha512-zj0lJPZxQanXKD8ae2kYnweT0kpp1CzpHYAkaBjTrw2k6ZMfr/UPlp0/ugCjWEokBqh79RUADLkKJJPce/yoSQ==",
       "dependencies": {
-        "@patternfly/react-icons": "^6.0.0",
-        "@patternfly/react-styles": "^6.0.0",
-        "@patternfly/react-tokens": "^6.0.0",
-        "focus-trap": "7.6.0",
-        "react-dropzone": "^14.2.3",
-        "tslib": "^2.7.0"
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
+        "focus-trap": "7.6.2",
+        "react-dropzone": "^14.3.5",
+        "tslib": "^2.8.1"
       },
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -3462,26 +3462,40 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.0.0.tgz",
-      "integrity": "sha512-ZFrsBVKrAp0DZrPOss98OA/EVUL4F0frXhR1uBId9+3ZrRArdKTgYgmQUCeSzMbxnSlxpmm3a2L05XQ36VUVbw==",
-      "license": "MIT",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.1.0.tgz",
+      "integrity": "sha512-V1w/j19YmOgvh72IRRf1p07k+u4M5+9P+o/IxunlF0fWzLDX4Hf+utBI11A8cRfUzpQN7eLw/vZIS3BLM8Ge3Q==",
       "peerDependencies": {
         "react": "^17 || ^18",
         "react-dom": "^17 || ^18"
       }
     },
     "node_modules/@patternfly/react-styles": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.0.0.tgz",
-      "integrity": "sha512-fJFMB89sTRGlZTzTLmpRmthgOXqcN078scHMFJ3ttfi2D2btnem5oZrxmQ/gPZkZOxR+9MqwKDB6l3F5x1SqLQ==",
-      "license": "MIT"
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-styles/-/react-styles-6.1.0.tgz",
+      "integrity": "sha512-JQ3zIl5SFiSB0YWVYibcUwgZdsp6Wn8hkfZ7KhtCjHFccSDdJexPOXVV1O9f2h4PfxTlY3YntZ81ZsguBx/Q7A=="
+    },
+    "node_modules/@patternfly/react-table": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.1.0.tgz",
+      "integrity": "sha512-eC8mKkvFR0btfv6yEOvE+J4gBXU8ZGe9i2RSezBM+MJaXEQt/CKRjV+SAB5EeE3PyBYKG8yYDdsOoNmaPxxvSA==",
+      "dependencies": {
+        "@patternfly/react-core": "^6.1.0",
+        "@patternfly/react-icons": "^6.1.0",
+        "@patternfly/react-styles": "^6.1.0",
+        "@patternfly/react-tokens": "^6.1.0",
+        "lodash": "^4.17.21",
+        "tslib": "^2.8.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
     },
     "node_modules/@patternfly/react-tokens": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.0.0.tgz",
-      "integrity": "sha512-xd0ynDkiIW2rp8jz4TNvR4Dyaw9kSMkZdsuYcLlFXCVmvX//Mnl4rhBnid/2j2TaqK0NbkyTTPnPY/BU7SfLVQ==",
-      "license": "MIT"
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.1.0.tgz",
+      "integrity": "sha512-t1UcHbOa4txczTR5UlnG4XcAAdnDSfSlCaOddw/HTqRF59pn2ks2JUu9sfnFRZ8SiAAxKRiYdX5bT7Mf4R24+w=="
     },
     "node_modules/@pkgr/core": {
       "version": "0.1.1",
@@ -9538,10 +9552,9 @@
       }
     },
     "node_modules/focus-trap": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.0.tgz",
-      "integrity": "sha512-1td0l3pMkWJLFipobUcGaf+5DTY4PLDDrcqoSaKP8ediO/CoWCCYk/fT/Y2A4e6TNB+Sh6clRJCjOPPnKoNHnQ==",
-      "license": "MIT",
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.2.tgz",
+      "integrity": "sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -20952,8 +20965,7 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "license": "MIT"
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "node_modules/temp-dir": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@nanostores/react": "^0.8.0",
     "@patternfly/patternfly": "^6.0.0",
     "@patternfly/react-core": "^6.0.0",
+    "@patternfly/react-table": "^6.0.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "astro": "^5.4.1",

--- a/src/components/PropsTable.tsx
+++ b/src/components/PropsTable.tsx
@@ -44,6 +44,7 @@ export const PropsTable: React.FunctionComponent<PropsTableProps> = ({
     : []
 
   if (betaDeprecatedProps.length) {
+    // eslint-disable-next-line no-console
     console.error(
       `The following ${componentName} props have both the isBeta and isDeprecated tag: ${betaDeprecatedProps.map((prop) => prop.name).join(', ')}`,
     )

--- a/src/components/PropsTable.tsx
+++ b/src/components/PropsTable.tsx
@@ -12,34 +12,39 @@ import { css } from '@patternfly/react-styles'
 import accessibleStyles from '@patternfly/react-styles/css/utilities/Accessibility/accessibility'
 import textStyles from '@patternfly/react-styles/css/utilities/Text/text'
 
-type ComponentProp = {
+export type ComponentProp = {
   name: string
   isRequired?: boolean
   isBeta?: boolean
+  isHidden?: boolean
   isDeprecated?: boolean
   type?: string
   defaultValue?: string
-  description: string
+  description?: string
 }
 
 type PropsTableProps = {
   componentName: string
+  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
   componentDescription?: string
   componentProps?: ComponentProp[]
 }
 
 export const PropsTable: React.FunctionComponent<PropsTableProps> = ({
   componentName,
+  headingLevel = 'h3',
   componentDescription,
   componentProps,
 }) => {
-  const hasPropsToRender = !!componentProps?.length
+  const SectionHeading = headingLevel
+  const publicProps = componentProps?.filter((prop) => !prop.isHidden)
+  const hasPropsToRender = !!publicProps?.length
   const betaDeprecatedProps = hasPropsToRender
-    ? componentProps.filter((prop) => prop.isBeta && prop.isDeprecated)
+    ? publicProps.filter((prop) => prop.isBeta && prop.isDeprecated)
     : []
 
   if (betaDeprecatedProps.length) {
-    throw new Error(
+    console.error(
       `The following ${componentName} props have both the isBeta and isDeprecated tag: ${betaDeprecatedProps.map((prop) => prop.name).join(', ')}`,
     )
   }
@@ -64,16 +69,19 @@ export const PropsTable: React.FunctionComponent<PropsTableProps> = ({
 
   return (
     <>
-      <h3>{componentName}</h3>
+      <SectionHeading>{componentName}</SectionHeading>
       <Stack hasGutter>
         {componentDescription && (
-          <div className={css(textStyles.textColorSubtle)}>
+          <div
+            data-testid="component-description"
+            className={css(textStyles.textColorSubtle)}
+          >
             {componentDescription}
           </div>
         )}
         {hasPropsToRender && (
           <>
-            <div id={`${componentName}-required`}>
+            <div id={`${componentName}-required-description`}>
               <span className={css(textStyles.textColorRequired)}>*</span>{' '}
               <span className={css(textStyles.textColorSubtle)}>
                 indicates a required prop
@@ -82,19 +90,19 @@ export const PropsTable: React.FunctionComponent<PropsTableProps> = ({
             <Table
               variant="compact"
               aria-label={`Props for ${componentName}`}
-              aria-describedby={`${componentName}-required`}
+              aria-describedby={`${componentName}-required-description`}
               gridBreakPoint="grid-lg"
             >
               <Thead>
                 <Tr>
                   <Th width={20}>Name</Th>
                   <Th width={20}>Type</Th>
-                  <Th>Default</Th>
+                  <Th width={10}>Default</Th>
                   <Th>Description</Th>
                 </Tr>
               </Thead>
               <Tbody>
-                {componentProps?.map((prop: ComponentProp) => (
+                {publicProps.map((prop: ComponentProp) => (
                   <Tr key={prop.name}>
                     <Td>
                       <TableText wrapModifier="breakWord">
@@ -121,17 +129,17 @@ export const PropsTable: React.FunctionComponent<PropsTableProps> = ({
                     </Td>
                     <Td>
                       <TableText wrapModifier="breakWord">
-                        {prop.type || 'No type info'}
+                        {prop.type || 'No type info available'}
                       </TableText>
                     </Td>
                     <Td>
                       <TableText wrapModifier="breakWord">
-                        {prop.defaultValue}
+                        {prop.defaultValue || '-'}
                       </TableText>
                     </Td>
                     <Td>
                       <TableText wrapModifier="breakWord">
-                        {prop.description}
+                        {prop.description || 'No description available.'}
                       </TableText>
                     </Td>
                   </Tr>

--- a/src/components/PropsTable.tsx
+++ b/src/components/PropsTable.tsx
@@ -1,0 +1,146 @@
+import { Label, Stack } from '@patternfly/react-core'
+import {
+  Table,
+  Thead,
+  Th,
+  Tr,
+  Tbody,
+  Td,
+  TableText,
+} from '@patternfly/react-table'
+import { css } from '@patternfly/react-styles'
+import accessibleStyles from '@patternfly/react-styles/css/utilities/Accessibility/accessibility'
+import textStyles from '@patternfly/react-styles/css/utilities/Text/text'
+
+type ComponentProp = {
+  name: string
+  isRequired?: boolean
+  isBeta?: boolean
+  isDeprecated?: boolean
+  type?: string
+  defaultValue?: string
+  description: string
+}
+
+type PropsTableProps = {
+  componentName: string
+  componentDescription?: string
+  componentProps?: ComponentProp[]
+}
+
+export const PropsTable: React.FunctionComponent<PropsTableProps> = ({
+  componentName,
+  componentDescription,
+  componentProps,
+}) => {
+  const hasPropsToRender = !!componentProps?.length
+  const betaDeprecatedProps = hasPropsToRender
+    ? componentProps.filter((prop) => prop.isBeta && prop.isDeprecated)
+    : []
+
+  if (betaDeprecatedProps.length) {
+    throw new Error(
+      `The following ${componentName} props have both the isBeta and isDeprecated tag: ${betaDeprecatedProps.map((prop) => prop.name).join(', ')}`,
+    )
+  }
+
+  const renderTagLabel = (componentProp: ComponentProp) => {
+    const { isBeta, isDeprecated } = componentProp
+    if (!isBeta && !isDeprecated) {
+      return null
+    }
+
+    return (
+      <Label
+        // Would need design eyes on outline vs filled
+        variant="outline"
+        color={`${isBeta ? 'blue' : 'orange'}`}
+        isCompact
+      >
+        {isBeta ? 'Beta' : 'Deprecated'}
+      </Label>
+    )
+  }
+
+  return (
+    <>
+      <h3>{componentName}</h3>
+      <Stack hasGutter>
+        {componentDescription && (
+          <div className={css(textStyles.textColorSubtle)}>
+            {componentDescription}
+          </div>
+        )}
+        {hasPropsToRender && (
+          <>
+            <div id={`${componentName}-required`}>
+              <span className={css(textStyles.textColorRequired)}>*</span>{' '}
+              <span className={css(textStyles.textColorSubtle)}>
+                indicates a required prop
+              </span>
+            </div>
+            <Table
+              variant="compact"
+              aria-label={`Props for ${componentName}`}
+              aria-describedby={`${componentName}-required`}
+              gridBreakPoint="grid-lg"
+            >
+              <Thead>
+                <Tr>
+                  <Th width={20}>Name</Th>
+                  <Th width={20}>Type</Th>
+                  <Th>Default</Th>
+                  <Th>Description</Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {componentProps?.map((prop: ComponentProp) => (
+                  <Tr key={prop.name}>
+                    <Td>
+                      <TableText wrapModifier="breakWord">
+                        {prop.name}
+                        {prop.isRequired ? (
+                          <>
+                            <span
+                              aria-hidden="true"
+                              className={css(textStyles.textColorRequired)}
+                            >
+                              *
+                            </span>
+                            <span
+                              className={css(accessibleStyles.screenReader)}
+                            >
+                              required
+                            </span>
+                          </>
+                        ) : (
+                          ''
+                        )}{' '}
+                        {renderTagLabel(prop)}
+                      </TableText>
+                    </Td>
+                    <Td>
+                      <TableText wrapModifier="breakWord">
+                        {prop.type || 'No type info'}
+                      </TableText>
+                    </Td>
+                    <Td>
+                      <TableText wrapModifier="breakWord">
+                        {prop.defaultValue}
+                      </TableText>
+                    </Td>
+                    <Td>
+                      <TableText wrapModifier="breakWord">
+                        {prop.description}
+                      </TableText>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </>
+        )}
+      </Stack>
+    </>
+  )
+}

--- a/src/components/PropsTable.tsx
+++ b/src/components/PropsTable.tsx
@@ -39,32 +39,39 @@ export const PropsTable: React.FunctionComponent<PropsTableProps> = ({
   const SectionHeading = headingLevel
   const publicProps = componentProps?.filter((prop) => !prop.isHidden)
   const hasPropsToRender = !!publicProps?.length
-  const betaDeprecatedProps = hasPropsToRender
-    ? publicProps.filter((prop) => prop.isBeta && prop.isDeprecated)
-    : []
-
-  if (betaDeprecatedProps.length) {
-    // eslint-disable-next-line no-console
-    console.error(
-      `The following ${componentName} props have both the isBeta and isDeprecated tag: ${betaDeprecatedProps.map((prop) => prop.name).join(', ')}`,
-    )
-  }
 
   const renderTagLabel = (componentProp: ComponentProp) => {
-    const { isBeta, isDeprecated } = componentProp
+    const { name, isBeta, isDeprecated } = componentProp
     if (!isBeta && !isDeprecated) {
       return null
     }
 
+    if (isBeta && isDeprecated) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `The ${name} prop for ${componentName} has both the isBeta and isDeprecated tag.`,
+      )
+    }
+
     return (
-      <Label
-        // Would need design eyes on outline vs filled
-        variant="outline"
-        color={`${isBeta ? 'blue' : 'orange'}`}
-        isCompact
-      >
+      <Label color={`${isBeta ? 'blue' : 'grey'}`} isCompact>
         {isBeta ? 'Beta' : 'Deprecated'}
       </Label>
+    )
+  }
+
+  const renderRequiredDescription = (isRequired: boolean | undefined) => {
+    if (!isRequired) {
+      return null
+    }
+
+    return (
+      <>
+        <span aria-hidden="true" className={css(textStyles.textColorRequired)}>
+          *
+        </span>
+        <span className={css(accessibleStyles.screenReader)}>required</span>
+      </>
     )
   }
 
@@ -108,23 +115,7 @@ export const PropsTable: React.FunctionComponent<PropsTableProps> = ({
                     <Td>
                       <TableText wrapModifier="breakWord">
                         {prop.name}
-                        {prop.isRequired ? (
-                          <>
-                            <span
-                              aria-hidden="true"
-                              className={css(textStyles.textColorRequired)}
-                            >
-                              *
-                            </span>
-                            <span
-                              className={css(accessibleStyles.screenReader)}
-                            >
-                              required
-                            </span>
-                          </>
-                        ) : (
-                          ''
-                        )}{' '}
+                        {renderRequiredDescription(prop.isRequired)}{' '}
                         {renderTagLabel(prop)}
                       </TableText>
                     </Td>

--- a/src/components/__tests__/PropsTable.test.tsx
+++ b/src/components/__tests__/PropsTable.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, within } from '@testing-library/react'
 import { PropsTable, type ComponentProp } from '../PropsTable'
-import textStyles from '@patternfly/react-styles/css/utilities/Text/text'
 
 const componentName = 'TestComponent'
 const componentDescription =

--- a/src/components/__tests__/PropsTable.test.tsx
+++ b/src/components/__tests__/PropsTable.test.tsx
@@ -44,7 +44,9 @@ it('Renders component description when componentDescription is passed in', () =>
     />,
   )
 
-  expect(screen.getByText(componentDescription)).toBeVisible()
+  expect(screen.getByTestId('component-description')).toHaveTextContent(
+    componentDescription,
+  )
 })
 
 it('Does not render props table if componentProps is not passed in', () => {
@@ -83,7 +85,7 @@ it('Throws error if component prop has isBeta and isDeprecated both set to true'
 
   expect(consoleSpy).toHaveBeenCalledTimes(1)
   expect(consoleSpy).toHaveBeenCalledWith(
-    'The following TestComponent props have both the isBeta and isDeprecated tag: propWithAllTableColumns',
+    `The ${propWithAllTableColumns.name} prop for TestComponent has both the isBeta and isDeprecated tag.`,
   )
   consoleSpy.mockRestore()
 })
@@ -101,7 +103,7 @@ it('Does not throw error if only one of isBeta or isDeprecated is passed', () =>
   consoleSpy.mockRestore()
 })
 
-it('Does not throw error if isBeta and isDeprecated both are not passed', () => {
+it('Does not throw error if neither isBeta nor isDeprecated are passed', () => {
   const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
   render(
     <PropsTable

--- a/src/components/__tests__/PropsTable.test.tsx
+++ b/src/components/__tests__/PropsTable.test.tsx
@@ -1,0 +1,310 @@
+import { render, screen, within } from '@testing-library/react'
+import { PropsTable, type ComponentProp } from '../PropsTable'
+import textStyles from '@patternfly/react-styles/css/utilities/Text/text'
+
+const componentName = 'TestComponent'
+const componentDescription =
+  'This is the testable component for the PropsTable.'
+const propWithAllTableColumns: ComponentProp = {
+  name: 'propWithAllTableColumns',
+  type: 'string | () => void',
+  defaultValue: 'foobarbaz',
+  description: 'This prop has data for all table fields.',
+}
+const propWithNameOnly: ComponentProp = {
+  name: 'propWithNameOnly',
+}
+
+it('Renders component name in a heading level 3 by default', () => {
+  render(<PropsTable componentName={componentName} />)
+
+  expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent(
+    componentName,
+  )
+})
+
+it('Renders component name in heading level when headingLevel is passed in', () => {
+  render(<PropsTable headingLevel="h2" componentName={componentName} />)
+
+  expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent(
+    componentName,
+  )
+})
+
+it('Does not render component description by default', () => {
+  render(<PropsTable componentName={componentName} />)
+
+  expect(screen.queryByTestId('component-description')).not.toBeInTheDocument()
+})
+
+it('Renders component description when componentDescription is passed in', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentDescription={componentDescription}
+    />,
+  )
+
+  expect(screen.getByText(componentDescription)).toBeVisible()
+})
+
+it('Does not render props table if componentProps is not passed in', () => {
+  render(<PropsTable componentName={componentName} />)
+
+  expect(screen.queryByRole('grid')).not.toBeInTheDocument()
+})
+
+it('Does not render props table if componentProps is empty array', () => {
+  render(<PropsTable componentName={componentName} componentProps={[]} />)
+
+  expect(screen.queryByRole('grid')).not.toBeInTheDocument()
+})
+
+it('Does not render props table if componentProps contains only hidden props', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[{ isHidden: true, ...propWithAllTableColumns }]}
+    />,
+  )
+
+  expect(screen.queryByRole('grid')).not.toBeInTheDocument()
+})
+
+it('Throws error if component prop has isBeta and isDeprecated both set to true', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[
+        { isBeta: true, isDeprecated: true, ...propWithAllTableColumns },
+      ]}
+    />,
+  )
+
+  expect(consoleSpy).toHaveBeenCalledTimes(1)
+  expect(consoleSpy).toHaveBeenCalledWith(
+    'The following TestComponent props have both the isBeta and isDeprecated tag: propWithAllTableColumns',
+  )
+  consoleSpy.mockRestore()
+})
+
+it('Does not throw error if only one of isBeta or isDeprecated is passed', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[{ isBeta: true, ...propWithAllTableColumns }]}
+    />,
+  )
+
+  expect(consoleSpy).not.toHaveBeenCalled()
+  consoleSpy.mockRestore()
+})
+
+it('Does not throw error if isBeta and isDeprecated both are not passed', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation()
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithAllTableColumns]}
+    />,
+  )
+
+  expect(consoleSpy).not.toHaveBeenCalled()
+  consoleSpy.mockRestore()
+})
+
+it('Renders props table with aria-label based on componentName', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithAllTableColumns]}
+    />,
+  )
+
+  expect(screen.getByRole('grid')).toHaveAccessibleName(
+    `Props for ${componentName}`,
+  )
+})
+
+it('Renders props table with aria-description referencing required prop text', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithAllTableColumns]}
+    />,
+  )
+
+  expect(screen.getByRole('grid')).toHaveAccessibleDescription(
+    `* indicates a required prop`,
+  )
+})
+
+it('Renders prop row with passed in componentProp data', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithAllTableColumns]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const propDataCells = within(tbody).getAllByRole('cell')
+
+  expect(propDataCells[0]).toHaveTextContent(propWithAllTableColumns.name)
+  expect(propDataCells[1]).toHaveTextContent(
+    propWithAllTableColumns.type as string,
+  )
+  expect(propDataCells[2]).toHaveTextContent(
+    propWithAllTableColumns.defaultValue as string,
+  )
+  expect(propDataCells[3]).toHaveTextContent(
+    propWithAllTableColumns.description as string,
+  )
+})
+
+it('Does not render prop as required by default', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithAllTableColumns]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const nameCell = within(tbody).getAllByRole('cell')[0]
+
+  expect(within(nameCell).queryByText('required')).not.toBeInTheDocument()
+})
+
+it('Renders prop as required when its isRequired property is true', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[{ isRequired: true, ...propWithAllTableColumns }]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const nameCell = within(tbody).getAllByRole('cell')[0]
+
+  expect(nameCell).toHaveTextContent(`${propWithAllTableColumns.name}*`)
+  expect(within(nameCell).getByText('required')).toBeInTheDocument()
+})
+
+it('Does not render prop as beta or deprecated by default', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithAllTableColumns]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const nameCell = within(tbody).getAllByRole('cell')[0]
+
+  expect(within(nameCell).queryByText(/beta/i)).not.toBeInTheDocument()
+  expect(within(nameCell).queryByText(/deprecated/i)).not.toBeInTheDocument()
+})
+
+it('Renders prop as beta when its isBeta property is true', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[{ isBeta: true, ...propWithAllTableColumns }]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const nameCell = within(tbody).getAllByRole('cell')[0]
+
+  expect(within(nameCell).getByText(/beta/i)).toBeInTheDocument()
+})
+
+it('Renders prop as deprecated when its isDeprecated property is true', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[{ isDeprecated: true, ...propWithAllTableColumns }]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const nameCell = within(tbody).getAllByRole('cell')[0]
+
+  expect(within(nameCell).getByText(/deprecated/i)).toBeInTheDocument()
+})
+
+it('Renders default content when type data is undefined', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithNameOnly]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const typeCell = within(tbody).getAllByRole('cell')[1]
+
+  expect(typeCell).toHaveTextContent('No type info available')
+})
+
+it('Renders default content when defaultValue data is undefined', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithNameOnly]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const defaultValueCell = within(tbody).getAllByRole('cell')[2]
+
+  expect(defaultValueCell).toHaveTextContent('-')
+})
+
+it('Renders default content when description data is undefined', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithNameOnly]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const descriptionCell = within(tbody).getAllByRole('cell')[3]
+
+  expect(descriptionCell).toHaveTextContent('No description available.')
+})
+
+it('Only renders rows for props that do not have their isHidden property set to true', () => {
+  render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[
+        { isHidden: true, ...propWithAllTableColumns },
+        propWithNameOnly,
+      ]}
+    />,
+  )
+
+  const tbody = screen.getAllByRole('rowgroup')[1]
+  const rows = within(tbody).getAllByRole('row')
+
+  expect(rows).toHaveLength(1)
+  Object.values(propWithAllTableColumns).forEach((value) => {
+    expect(rows[0]).not.toHaveTextContent(value as string)
+  })
+})
+
+it('Matches snapshot', () => {
+  const { asFragment } = render(
+    <PropsTable
+      componentName={componentName}
+      componentProps={[propWithAllTableColumns, propWithNameOnly]}
+    />,
+  )
+
+  expect(asFragment()).toMatchSnapshot()
+})

--- a/src/components/__tests__/__snapshots__/PropsTable.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/PropsTable.test.tsx.snap
@@ -1,0 +1,176 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Matches snapshot 1`] = `
+<DocumentFragment>
+  <h3>
+    TestComponent
+  </h3>
+  <div
+    class="pf-v6-l-stack pf-m-gutter"
+  >
+    <div
+      id="TestComponent-required-description"
+    >
+      <span
+        class="pf-v6-u-text-color-required"
+      >
+        *
+      </span>
+       
+      <span
+        class="pf-v6-u-text-color-subtle"
+      >
+        indicates a required prop
+      </span>
+    </div>
+    <table
+      aria-describedby="TestComponent-required-description"
+      aria-label="Props for TestComponent"
+      class="pf-v6-c-table pf-m-grid-lg pf-m-compact"
+      data-ouia-component-id="OUIA-Generated-Table-16"
+      data-ouia-component-type="PF6/Table"
+      data-ouia-safe="true"
+      role="grid"
+    >
+      <thead
+        class="pf-v6-c-table__thead"
+      >
+        <tr
+          class="pf-v6-c-table__tr"
+          data-ouia-component-id="OUIA-Generated-TableRow-31"
+          data-ouia-component-type="PF6/TableRow"
+          data-ouia-safe="true"
+        >
+          <th
+            class="pf-v6-c-table__th pf-m-width-20"
+            scope="col"
+            tabindex="-1"
+          >
+            Name
+          </th>
+          <th
+            class="pf-v6-c-table__th pf-m-width-20"
+            scope="col"
+            tabindex="-1"
+          >
+            Type
+          </th>
+          <th
+            class="pf-v6-c-table__th pf-m-width-10"
+            scope="col"
+            tabindex="-1"
+          >
+            Default
+          </th>
+          <th
+            class="pf-v6-c-table__th"
+            scope="col"
+            tabindex="-1"
+          >
+            Description
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        class="pf-v6-c-table__tbody"
+        role="rowgroup"
+      >
+        <tr
+          class="pf-v6-c-table__tr"
+          data-ouia-component-id="OUIA-Generated-TableRow-32"
+          data-ouia-component-type="PF6/TableRow"
+          data-ouia-safe="true"
+        >
+          <td
+            class="pf-v6-c-table__td"
+            tabindex="-1"
+          >
+            <span
+              class="pf-m-break-word pf-v6-c-table__text"
+            >
+              propWithAllTableColumns 
+            </span>
+          </td>
+          <td
+            class="pf-v6-c-table__td"
+            tabindex="-1"
+          >
+            <span
+              class="pf-m-break-word pf-v6-c-table__text"
+            >
+              string | () =&gt; void
+            </span>
+          </td>
+          <td
+            class="pf-v6-c-table__td"
+            tabindex="-1"
+          >
+            <span
+              class="pf-m-break-word pf-v6-c-table__text"
+            >
+              foobarbaz
+            </span>
+          </td>
+          <td
+            class="pf-v6-c-table__td"
+            tabindex="-1"
+          >
+            <span
+              class="pf-m-break-word pf-v6-c-table__text"
+            >
+              This prop has data for all table fields.
+            </span>
+          </td>
+        </tr>
+        <tr
+          class="pf-v6-c-table__tr"
+          data-ouia-component-id="OUIA-Generated-TableRow-33"
+          data-ouia-component-type="PF6/TableRow"
+          data-ouia-safe="true"
+        >
+          <td
+            class="pf-v6-c-table__td"
+            tabindex="-1"
+          >
+            <span
+              class="pf-m-break-word pf-v6-c-table__text"
+            >
+              propWithNameOnly 
+            </span>
+          </td>
+          <td
+            class="pf-v6-c-table__td"
+            tabindex="-1"
+          >
+            <span
+              class="pf-m-break-word pf-v6-c-table__text"
+            >
+              No type info available
+            </span>
+          </td>
+          <td
+            class="pf-v6-c-table__td"
+            tabindex="-1"
+          >
+            <span
+              class="pf-m-break-word pf-v6-c-table__text"
+            >
+              -
+            </span>
+          </td>
+          <td
+            class="pf-v6-c-table__td"
+            tabindex="-1"
+          >
+            <span
+              class="pf-m-break-word pf-v6-c-table__text"
+            >
+              No description available.
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</DocumentFragment>
+`;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,37 +1,6 @@
 ---
 import '../styles/global.scss'
 import MainLayout from '../layouts/Main.astro'
-import { PropsTable } from '../components/PropsTable'
-
-const propsData = [
-  {
-    name: 'variant',
-    type: "'success' | 'danger' | 'warning' | 'info' | 'custom'",
-    defaultValue: '',
-    description: 'Adds alert variant styles.',
-    isBeta: true,
-  },
-  {
-    name: 'children',
-    isRequired: true,
-    type: 'ReactNode',
-    defaultValue: '',
-  },
-  {
-    name: 'timeoutAnimation',
-    isRequired: false,
-    type: undefined,
-    defaultValue: '3000',
-    description:
-      'If the user hovers over the alert and `timeout` expires, this is how long to wait before finally dismissing the alert.',
-    isDeprecated: true,
-  },
-  {
-    name: 'innerRef',
-    isHidden: true,
-    description: 'Ref to pass',
-  },
-]
 ---
 
 <html lang="en">
@@ -43,17 +12,6 @@ const propsData = [
     <title>PatternFly</title>
   </head>
   <body>
-    <MainLayout title="PatternFly X Astro">
-      <PropsTable
-        componentName="Alert"
-        componentDescription="The main alert component."
-        componentProps={propsData}
-      />
-      <PropsTable
-        componentName="AlertGroup"
-        componentDescription="The container to render a list of alerts."
-      />
-      <PropsTable componentName="AlertTitle" />
-    </MainLayout>
+    <MainLayout title="PatternFly X Astro"> Page content </MainLayout>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,33 @@
 ---
 import '../styles/global.scss'
 import MainLayout from '../layouts/Main.astro'
+import { PropsTable } from '../components/PropsTable'
+
+const propsData = [
+  {
+    name: 'variant',
+    type: "'success' | 'danger' | 'warning' | 'info' | 'custom'",
+    defaultValue: '',
+    description: 'Adds alert variant styles.',
+    isBeta: true,
+  },
+  {
+    name: 'children',
+    isRequired: true,
+    type: 'ReactNode',
+    defaultValue: '',
+    description: 'Content rendered inside the alert.',
+  },
+  {
+    name: 'timeoutAnimation',
+    isRequired: false,
+    type: undefined,
+    defaultValue: '3000',
+    description:
+      'If the user hovers over the alert and `timeout` expires, this is how long to wait before finally dismissing the alert.',
+    isDeprecated: true,
+  },
+]
 ---
 
 <html lang="en">
@@ -12,6 +39,16 @@ import MainLayout from '../layouts/Main.astro'
     <title>PatternFly</title>
   </head>
   <body>
-    <MainLayout title="PatternFly X Astro"> Page content </MainLayout>
+    <MainLayout title="PatternFly X Astro">
+      <PropsTable
+        componentName="Alert"
+        componentDescription="The main alert component."
+        componentProps={propsData}
+      />
+      <PropsTable
+        componentName="AlertGroup"
+        componentDescription="The container to render a list of alerts."
+      />
+    </MainLayout>
   </body>
 </html>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,7 +16,6 @@ const propsData = [
     isRequired: true,
     type: 'ReactNode',
     defaultValue: '',
-    description: 'Content rendered inside the alert.',
   },
   {
     name: 'timeoutAnimation',
@@ -26,6 +25,11 @@ const propsData = [
     description:
       'If the user hovers over the alert and `timeout` expires, this is how long to wait before finally dismissing the alert.',
     isDeprecated: true,
+  },
+  {
+    name: 'innerRef',
+    isHidden: true,
+    description: 'Ref to pass',
   },
 ]
 ---
@@ -49,6 +53,7 @@ const propsData = [
         componentName="AlertGroup"
         componentDescription="The container to render a list of alerts."
       />
+      <PropsTable componentName="AlertTitle" />
     </MainLayout>
   </body>
 </html>


### PR DESCRIPTION
Towards #15 

Note that I updated the index file to render some dummy data, I'll back that out after this gets reviews in case anyone has comments on the visuals.

Things to consider:

- Do we want this table to handle sorting items alphabetically, or should whatever is passing the date into the table handle it? Probably the latter if we anticipate using this data elsewhere for whatever reason.
  - Austin mentioned the backend handling this, I'd be fine with that. Adding sorting functionality in the future is also an option
- FWIW, here's a screenshot of something I toyed with where we display an empty state in the table if no props are found, rather than just omitting the table completely
  ![image](https://github.com/user-attachments/assets/3431c2ba-842d-4b62-a66c-9e635640c49d)
