### PR TITLE
feat(Tabs): add logic for component tabs & nav routing

### DIFF
--- a/src/components/NavEntry.tsx
+++ b/src/components/NavEntry.tsx
@@ -20,7 +20,10 @@ export const NavEntry = ({ entry, isActive }: NavEntryProps) => {
   const { id } = entry
   const { id: entryTitle, section } = entry.data
 
-  const _id = section === 'components' ? kebabCase(entryTitle) : id
+  const _id =
+    section === 'components' || section === 'layouts'
+      ? kebabCase(entryTitle)
+      : id
   return (
     <NavItem
       itemId={_id}

--- a/src/components/NavEntry.tsx
+++ b/src/components/NavEntry.tsx
@@ -1,10 +1,12 @@
 import { NavItem } from '@patternfly/react-core'
+import { kebabCase } from 'change-case'
 
 export interface TextContentEntry {
   id: string
   data: {
     id: string
     section: string
+    tab?: string
   }
   collection: string
 }
@@ -18,8 +20,14 @@ export const NavEntry = ({ entry, isActive }: NavEntryProps) => {
   const { id } = entry
   const { id: entryTitle, section } = entry.data
 
+  const _id = section === 'components' ? kebabCase(entryTitle) : id
   return (
-    <NavItem itemId={id} to={`/${section}/${id}`} isActive={isActive} id={`nav-entry-${id}`}>
+    <NavItem
+      itemId={_id}
+      to={`/${section}/${_id}`}
+      isActive={isActive}
+      id={`nav-entry-${_id}`}
+    >
       {entryTitle}
     </NavItem>
   )

--- a/src/components/NavSection.tsx
+++ b/src/components/NavSection.tsx
@@ -23,7 +23,7 @@ export const NavSection = ({
   const isActive = sortedNavEntries.some((entry) => entry.id === activeItem)
 
   let navItems = sortedNavEntries
-  if (sectionId === 'components') { 
+  if (sectionId === 'components' || sectionId === 'layouts') {
     // only display unique entry.data.id in the nav list if the section is components
     navItems = [
       ...sortedNavEntries

--- a/src/components/NavSection.tsx
+++ b/src/components/NavSection.tsx
@@ -23,7 +23,8 @@ export const NavSection = ({
   const isActive = sortedNavEntries.some((entry) => entry.id === activeItem)
 
   let navItems = sortedNavEntries
-  if (sectionId === 'components') {
+  if (sectionId === 'components') { 
+    // only display unique entry.data.id in the nav list if the section is components
     navItems = [
       ...sortedNavEntries
         .reduce((map, entry) => {

--- a/src/components/NavSection.tsx
+++ b/src/components/NavSection.tsx
@@ -27,12 +27,7 @@ export const NavSection = ({
     navItems = [
       ...sortedNavEntries
         .reduce((map, entry) => {
-          if (
-            !map.has(entry.data.id) ||
-            (entry.data?.tab === 'react' &&
-              map.has(entry.data.id) &&
-              map.get(entry.data.id).data.tab === 'html')
-          ) {
+          if (!map.has(entry.data.id)) {
             map.set(entry.data.id, entry)
           }
           return map

--- a/src/components/NavSection.tsx
+++ b/src/components/NavSection.tsx
@@ -1,6 +1,7 @@
 import { NavExpandable } from '@patternfly/react-core'
 import { sentenceCase } from 'change-case'
 import { NavEntry, type TextContentEntry } from './NavEntry'
+import { kebabCase } from 'change-case'
 
 interface NavSectionProps {
   entries: TextContentEntry[]
@@ -21,8 +22,34 @@ export const NavSection = ({
 
   const isActive = sortedNavEntries.some((entry) => entry.id === activeItem)
 
-  const items = sortedNavEntries.map((entry) => (
-    <NavEntry key={entry.id} entry={entry} isActive={activeItem === entry.id} />
+  let navItems = sortedNavEntries
+  if (sectionId === 'components') {
+    navItems = [
+      ...sortedNavEntries
+        .reduce((map, entry) => {
+          if (
+            !map.has(entry.data.id) ||
+            (entry.data?.tab === 'react' &&
+              map.has(entry.data.id) &&
+              map.get(entry.data.id).data.tab === 'html')
+          ) {
+            map.set(entry.data.id, entry)
+          }
+          return map
+        }, new Map())
+        .values(),
+    ]
+  }
+
+  const items = navItems.map((entry) => (
+    <NavEntry
+      key={entry.id}
+      entry={entry}
+      isActive={
+        activeItem === entry.id ||
+        window.location.pathname.includes(kebabCase(entry.data.id))
+      }
+    />
   ))
 
   return (

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -8,6 +8,9 @@ import { content } from "../content"
 const collections = await Promise.all(content.map(async (entry) => await getCollection(entry.name as 'textContent')))
 
 const navEntries = collections.flat();
+// filter out duplicate component entries - default to react path
+// use entry.data.id for links here instead of entry.id because of filepaths
+// note: filepaths may not be unique, may want to consider using package name as well
 ---
 
 <ReactNav client:only="react" navEntries={navEntries} transition:animate="fade" />

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -8,9 +8,6 @@ import { content } from "../content"
 const collections = await Promise.all(content.map(async (entry) => await getCollection(entry.name as 'textContent')))
 
 const navEntries = collections.flat();
-// filter out duplicate component entries - default to react path
-// use entry.data.id for links here instead of entry.id because of filepaths
-// note: filepaths may not be unique, may want to consider using package name as well
 ---
 
 <ReactNav client:only="react" navEntries={navEntries} transition:animate="fade" />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -13,7 +13,7 @@ export const Navigation: React.FunctionComponent<NavigationProps> = ({
   const [activeItem, setActiveItem] = useState('')
 
   useEffect(() => {
-    setActiveItem(window.location.pathname.split('/').reverse()[0])
+    setActiveItem(window.location.pathname.split('/').reverse()[0]) // won't work with tabs
   }, [])
 
   const onNavSelect = (

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -13,7 +13,8 @@ export const Navigation: React.FunctionComponent<NavigationProps> = ({
   const [activeItem, setActiveItem] = useState('')
 
   useEffect(() => {
-    setActiveItem(window.location.pathname.split('/').reverse()[0]) // won't work with tabs
+    // TODO: Needs an alternate solution because of /tab in the path
+    setActiveItem(window.location.pathname.split('/').reverse()[0]) 
   }, [])
 
   const onNavSelect = (

--- a/src/components/Page.astro
+++ b/src/components/Page.astro
@@ -1,6 +1,6 @@
 ---
 import styles from '@patternfly/react-styles/css/components/Page/page'
-import { Content, PageSection } from '@patternfly/react-core'
+import { PageSection } from '@patternfly/react-core'
 ---
 
 <div class={styles.page}>
@@ -10,9 +10,7 @@ import { Content, PageSection } from '@patternfly/react-core'
   <div class={styles.pageMainContainer}>
     <main class={styles.pageMain}>
       <PageSection transition:animate="none">
-        <Content>
-          <slot />
-        </Content>
+        <slot />
       </PageSection>
     </main>
   </div>

--- a/src/components/__tests__/NavSection.test.tsx
+++ b/src/components/__tests__/NavSection.test.tsx
@@ -20,6 +20,24 @@ const mockEntries: TextContentEntry[] = [
   },
 ]
 
+const dupedEntries: TextContentEntry[] = [
+  {
+    id: 'entry1',
+    data: { id: 'Entry1', section: 'components' },
+    collection: 'react',
+  },
+  {
+    id: 'entry2',
+    data: { id: 'Entry1', section: 'components' },
+    collection: 'react',
+  },
+  {
+    id: 'entry3',
+    data: { id: 'Entry2', section: 'components' },
+    collection: 'react',
+  },
+]
+
 it('renders without crashing', () => {
   render(
     <NavSection
@@ -140,4 +158,46 @@ it('matches snapshot', () => {
     />,
   )
   expect(asFragment()).toMatchSnapshot()
+})
+
+it('dedupes and renders correct number of entries for components section', () => {
+  Object.defineProperty(window, 'location', {
+    value: {
+      pathname: '/foo/components',
+    },
+    writable: true,
+  })
+
+  render(
+    <NavSection
+      entries={dupedEntries}
+      sectionId="components"
+      activeItem="entry1"
+    />,
+  )
+
+  expect(screen.getAllByRole('listitem')).toHaveLength(3)
+  expect(screen.getByRole('link', { name: 'Entry1' })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: 'Entry2' })).toBeInTheDocument()
+})
+
+it('dedupes and renders correct number of entries for layouts section', () => {
+  Object.defineProperty(window, 'location', {
+    value: {
+      pathname: '/foo/layouts',
+    },
+    writable: true,
+  })
+
+  render(
+    <NavSection
+      entries={dupedEntries}
+      sectionId="layouts"
+      activeItem="entry1"
+    />,
+  )
+
+  expect(screen.getAllByRole('listitem')).toHaveLength(3)
+  expect(screen.getByRole('link', { name: 'Entry1' })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: 'Entry2' })).toBeInTheDocument()
 })

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,9 +14,10 @@ function defineContent(contentObj: CollectionDefinition) {
     return
   }
 
+  // Todo: expand to cover deprecated & demos tabs (look in filepath, or enforce tab in frontmatter for nonstandard tabs)
   const tabMap: any = {
-    'react-component-docs': 'react', // look in filepath for demos, look for deprecated flag or source flag for dep
-    'core-component-docs': 'html' // or force tab in frontmatter for non-base tabs
+    'react-component-docs': 'react',
+    'core-component-docs': 'html' 
   };
 
   return defineCollection({

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,7 +14,7 @@ function defineContent(contentObj: CollectionDefinition) {
     return
   }
 
-  // Todo: expand to cover deprecated & demos tabs (look in filepath, or enforce tab in frontmatter for nonstandard tabs)
+  // Todo: expand for other packages that remain under the react umbrella (Table, CodeEditor, etc)
   const tabMap: any = {
     'react-component-docs': 'react',
     'core-component-docs': 'html' 
@@ -27,7 +27,7 @@ function defineContent(contentObj: CollectionDefinition) {
       section: z.string(),
       subsection: z.string().optional(),
       title: z.string().optional(),
-      tab: z.string().optional().default(tabMap[name])
+      tab: z.string().optional().default(tabMap[name]),
       // package: z.string().optional().default(packageName as string)
     }),
   })

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,12 +14,20 @@ function defineContent(contentObj: CollectionDefinition) {
     return
   }
 
+  const tabMap: any = {
+    'react-component-docs': 'react', // look in filepath for demos, look for deprecated flag or source flag for dep
+    'core-component-docs': 'html' // or force tab in frontmatter for non-base tabs
+  };
+
   return defineCollection({
     loader: glob({ base: dir, pattern }),
     schema: z.object({
       id: z.string(),
       section: z.string(),
+      subsection: z.string().optional(),
       title: z.string().optional(),
+      tab: z.string().optional().default(tabMap[name])
+      // package: z.string().optional().default(packageName as string)
     }),
   })
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -14,7 +14,7 @@ function defineContent(contentObj: CollectionDefinition) {
     return
   }
 
-  // Todo: expand for other packages that remain under the react umbrella (Table, CodeEditor, etc)
+  // TODO: Expand for other packages that remain under the react umbrella (Table, CodeEditor, etc)
   const tabMap: any = {
     'react-component-docs': 'react',
     'core-component-docs': 'html' 
@@ -27,8 +27,7 @@ function defineContent(contentObj: CollectionDefinition) {
       section: z.string(),
       subsection: z.string().optional(),
       title: z.string().optional(),
-      tab: z.string().optional().default(tabMap[name]),
-      // package: z.string().optional().default(packageName as string)
+      tab: z.string().optional().default(tabMap[name])
     }),
   })
 }

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,13 +1,14 @@
 export const content = [
-  { base: 'textContent', pattern: '*.md', name: "textContent" }, 
-  {
-    "packageName":"@patternfly/react-core",
-    "pattern":"**/examples/**/*.md", // had to update the pattern to bring in demos docs
-    "name":"react-component-docs"
-  }, 
-  {
-    "packageName":"@patternfly/patternfly",
-    "pattern":"**/examples/**/*.md", // had to update the pattern to bring in demos docs
-    "name":"core-component-docs"
-  }
+  { base: 'textContent', pattern: '*.md', name: "textContent" } 
+  // TODO: Remove. Uncomment for local testing.
+  // {
+  //   "packageName":"@patternfly/react-core",
+  //   "pattern":"**/examples/**/*.md", // had to update this pattern to bring in demos docs
+  //   "name":"react-component-docs"
+  // }, 
+  // {
+  //   "packageName":"@patternfly/patternfly",
+  //   "pattern":"**/examples/**/*.md", // had to update this pattern to bring in demos docs
+  //   "name":"core-component-docs"
+  // }
 ]

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,1 +1,19 @@
-export const content = [{ base: 'textContent', pattern: '*.md', name: "textContent" }, { base: 'dir', pattern: '*.md', name: "dir" }]
+export const content = [
+  { base: 'textContent', pattern: '*.md', name: "textContent" }, 
+  {
+    "packageName":"@patternfly/react-core",
+    "pattern":"**/components/**/*.md",
+    "name":"react-component-docs"
+    // "build": {
+    //   "format": "directory"
+    // }
+  }, 
+  {
+    "packageName":"@patternfly/patternfly",
+    "pattern":"**/components/**/*.md",
+    "name":"core-component-docs"
+    // "build": {
+    //   "format": "directory"
+    // }
+  }
+]

--- a/src/content.ts
+++ b/src/content.ts
@@ -2,12 +2,12 @@ export const content = [
   { base: 'textContent', pattern: '*.md', name: "textContent" }, 
   {
     "packageName":"@patternfly/react-core",
-    "pattern":"**/components/**/*.md",
+    "pattern":"**/examples/**/*.md", // had to update the pattern to bring in demos docs
     "name":"react-component-docs"
   }, 
   {
     "packageName":"@patternfly/patternfly",
-    "pattern":"**/components/**/*.md",
+    "pattern":"**/examples/**/*.md", // had to update the pattern to bring in demos docs
     "name":"core-component-docs"
   }
 ]

--- a/src/content.ts
+++ b/src/content.ts
@@ -4,16 +4,10 @@ export const content = [
     "packageName":"@patternfly/react-core",
     "pattern":"**/components/**/*.md",
     "name":"react-component-docs"
-    // "build": {
-    //   "format": "directory"
-    // }
   }, 
   {
     "packageName":"@patternfly/patternfly",
     "pattern":"**/components/**/*.md",
     "name":"core-component-docs"
-    // "build": {
-    //   "format": "directory"
-    // }
   }
 ]

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,6 +1,6 @@
 export const componentTabs: any = {};
 
-export const tabNameMapping: any = {
+export const tabNames: any = {
   'react': 'React',
   'react-demos': 'React demos',
   'react-deprecated': 'React deprecated',

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -1,0 +1,9 @@
+export const componentTabs: any = {};
+
+export const tabNameMapping: any = {
+  'react': 'React',
+  'react-demos': 'React demos',
+  'react-deprecated': 'React deprecated',
+  'html': 'HTML',
+  'html-demos': 'HTML demos'
+};

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -9,12 +9,14 @@ export const tabNames: any = {
 };
 
 export const buildTab = (entry: any, tab: string) => {
+  const tabEntry = componentTabs[entry.data.id]
+
   // if no dictionary entry exists, and tab data exists
-  if(componentTabs[entry.data.id] === undefined && tab) { 
-    componentTabs[entry.data.id] = [tab];
+  if(tabEntry === undefined && tab) { 
+    componentTabs[entry.data.id] = [tab]
   // if dictionary entry & tab data exists, and entry does not include tab
-  } else if (componentTabs[entry.data.id] && tab && !componentTabs[entry.data.id].includes(tab)) { 
-    componentTabs[entry.data.id] = [...componentTabs[entry.data.id], tab];
+  } else if (tabEntry && tab && !tabEntry.includes(tab)) { 
+    componentTabs[entry.data.id] = [...tabEntry, tab];
   }
 }
 

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -7,3 +7,45 @@ export const tabNames: any = {
   'html': 'HTML',
   'html-demos': 'HTML demos'
 };
+
+export const buildTab = (entry: any, tab: string) => {
+  // if no dictionary entry exists, and tab data exists
+  if(componentTabs[entry.data.id] === undefined && tab) { 
+    componentTabs[entry.data.id] = [tab];
+  // if dictionary entry & tab data exists, and entry does not include tab
+  } else if (componentTabs[entry.data.id] && tab && !componentTabs[entry.data.id].includes(tab)) { 
+    componentTabs[entry.data.id] = [...componentTabs[entry.data.id], tab];
+  }
+}
+
+export const sortTabs = () => {
+  const defaultOrder = 50;
+  const sourceOrder: any = {
+    react: 1,
+    'react-next': 1.1,
+    'react-demos': 2,
+    'react-deprecated': 2.1,
+    html: 3,
+    'html-demos': 4,
+    'design-guidelines': 99,
+    'accessibility': 100,
+    'upgrade-guide': 101,
+    'release-notes': 102,
+  };
+  
+  const sortSources = (s1: string, s2: string) => {
+    const s1Index = sourceOrder[s1] || defaultOrder;
+    const s2Index = sourceOrder[s2] || defaultOrder;
+    if (s1Index === defaultOrder && s2Index === defaultOrder) {
+      return s1.localeCompare(s2);
+    }
+  
+    return s1Index > s2Index ? 1 : -1;
+  }
+  
+  // Sort tabs entries based on above sort order
+  // Ensures all tabs are displayed in a consistent order & which tab gets displayed for a component route without a tab 
+  Object.values(componentTabs).map((tabs: any) => {
+    tabs.sort(sortSources)
+  })
+}

--- a/src/pages/[section]/[...page].astro
+++ b/src/pages/[section]/[...page].astro
@@ -3,29 +3,37 @@ import { getCollection, render } from 'astro:content'
 import { Title } from '@patternfly/react-core'
 import MainLayout from '../../layouts/Main.astro'
 import { content } from "../../content"
+import { kebabCase } from 'change-case'
+import { componentTabs } from '../../globals'
 
 export async function getStaticPaths() {
   const collections = await Promise.all(content.map(async (entry) => await getCollection(entry.name as 'textContent')))
 
   return collections.flat().map((entry) => ({
-      params: { id: entry.id, section: entry.data.section },
+      params: { page: kebabCase(entry.data.id), section: entry.data.section },
       props: { entry, title: entry.data.title },
     })
   )
 }
 
+
 const { entry } = Astro.props
-const { title } = entry.data
+const { title, id, section } = entry.data
 const { Content } = await render(entry)
+
+if(section === 'components') { // if section is components, rewrite to first tab content
+  return Astro.rewrite(`/components/${kebabCase(id)}/${componentTabs[id][0]}`);
+}
 ---
 
 <MainLayout>
   {
     title && (
       <Title headingLevel="h1" size="4xl">
-        {title}
+        {title} 
       </Title>
     )
   }
+  AM I HERE?
   <Content />
 </MainLayout>

--- a/src/pages/[section]/[...page].astro
+++ b/src/pages/[section]/[...page].astro
@@ -34,6 +34,5 @@ if(section === 'components') { // if section is components, rewrite to first tab
       </Title>
     )
   }
-  AM I HERE?
   <Content />
 </MainLayout>

--- a/src/pages/[section]/[page]/[...tab].astro
+++ b/src/pages/[section]/[page]/[...tab].astro
@@ -4,7 +4,7 @@ import { Title, PageSection, Content as PFContent } from '@patternfly/react-core
 import MainLayout from '../../../layouts/Main.astro'
 import { content } from "../../../content"
 import { kebabCase } from 'change-case'
-import { componentTabs, tabNameMapping } from '../../../globals';
+import { componentTabs, tabNames } from '../../../globals';
 
 export async function getStaticPaths() {
   const collections = await Promise.all(content.map(async (entry) => await getCollection(entry.name as 'textContent')))
@@ -91,7 +91,7 @@ const currentPath = Astro.url.pathname;
               class={`pf-v6-c-tabs__item${currentPath === `/${section}/${kebabCase(id)}/${tab}` ? ' pf-m-current' : ''}`}
             >
               <a class="pf-v6-c-tabs__link" href={`/${section}/${kebabCase(id)}/${tab}`}>
-                {tabNameMapping[tab]}
+                {tabNames[tab]}
               </a>
             </li>
           ))}

--- a/src/pages/[section]/[page]/[...tab].astro
+++ b/src/pages/[section]/[page]/[...tab].astro
@@ -10,6 +10,7 @@ export async function getStaticPaths() {
   const collections = await Promise.all(content.map(async (entry) => await getCollection(entry.name as 'textContent')))
 
   const flatCol =  collections.flat().map((entry) => {
+    // Build tabs dictionary
     // if no dictionary entry exists, and tab data exists
     if(componentTabs[entry.data.id] === undefined && entry.data.tab) { 
       componentTabs[entry.data.id] = [entry.data.tab];
@@ -48,6 +49,8 @@ export async function getStaticPaths() {
     return s1Index > s2Index ? 1 : -1;
   }
 
+  // Sort tabs entries based on above sort order
+  // Ensures all tabs are displayed in a consistent order & which tab gets displayed for a component route without a tab 
   Object.values(componentTabs).map((tabs: any) => {
     tabs.sort(sortSources)
   })

--- a/src/pages/[section]/[page]/[...tab].astro
+++ b/src/pages/[section]/[page]/[...tab].astro
@@ -11,16 +11,25 @@ export async function getStaticPaths() {
 
   const flatCol =  collections.flat().map((entry) => {
     // Build tabs dictionary
+    let tab = entry.data.tab;
+    if(tab === 'react' || tab === 'html') { // if tab is default repo value, check for demos/deprecated
+      if(entry.id.includes('demos')) {
+        tab = `${tab}-demos`;
+      } else if (entry.id.includes('deprecated')) {
+        tab = `${tab}-deprecated`;
+      }
+    }
+
     // if no dictionary entry exists, and tab data exists
-    if(componentTabs[entry.data.id] === undefined && entry.data.tab) { 
-      componentTabs[entry.data.id] = [entry.data.tab];
+    if(componentTabs[entry.data.id] === undefined && tab) { 
+      componentTabs[entry.data.id] = [tab];
     // if dictionary entry & tab data exists, and entry does not include tab
-    } else if (componentTabs[entry.data.id] && entry.data.tab && !componentTabs[entry.data.id].includes(entry.data.tab)) { 
-      componentTabs[entry.data.id] = [...componentTabs[entry.data.id], entry.data.tab];
+    } else if (componentTabs[entry.data.id] && tab && !componentTabs[entry.data.id].includes(tab)) { 
+      componentTabs[entry.data.id] = [...componentTabs[entry.data.id], tab];
     }
 
     return {
-      params: { page: kebabCase(entry.data.id), section: entry.data.section, tab: entry.data.tab },
+      params: { page: kebabCase(entry.data.id), section: entry.data.section, tab },
       props: { entry, title: entry.data.title, component: entry.data.id,  package: entry.data.package },
     }
   })
@@ -72,13 +81,11 @@ const currentPath = Astro.url.pathname;
       </Title>
     )
   }
-  HELLO TAB 
-  <!-- {console.log(entry, id, componentTabs[id], currentPath)} -->
   {componentTabs[id] && (
     <PageSection id="ws-sticky-nav-tabs" stickyOnBreakpoint={{ default: 'top' }} type="tabs">
       <div class="pf-v6-c-tabs pf-m-page-insets pf-m-no-border-bottom">
         <ul class="pf-v6-c-tabs__list">
-          {componentTabs[id].map((tab: string, index: number) => ( // TODO: sort tabs array to standard
+          {componentTabs[id].map((tab: string) => (
             // eslint-disable-next-line react/jsx-key
             <li
               class={`pf-v6-c-tabs__item${currentPath === `/${section}/${kebabCase(id)}/${tab}` ? ' pf-m-current' : ''}`}

--- a/src/pages/[section]/[page]/[...tab].astro
+++ b/src/pages/[section]/[page]/[...tab].astro
@@ -4,7 +4,7 @@ import { Title, PageSection, Content as PFContent } from '@patternfly/react-core
 import MainLayout from '../../../layouts/Main.astro'
 import { content } from "../../../content"
 import { kebabCase } from 'change-case'
-import { componentTabs, tabNames } from '../../../globals';
+import { componentTabs, tabNames, buildTab, sortTabs } from '../../../globals';
 
 export async function getStaticPaths() {
   const collections = await Promise.all(content.map(async (entry) => await getCollection(entry.name as 'textContent')))
@@ -12,58 +12,22 @@ export async function getStaticPaths() {
   const flatCol =  collections.flat().map((entry) => {
     // Build tabs dictionary
     let tab = entry.data.tab;
-    if(tab === 'react' || tab === 'html') { // if tab is default repo value, check for demos/deprecated
+    if(tab) { // check for demos/deprecated
       if(entry.id.includes('demos')) {
         tab = `${tab}-demos`;
       } else if (entry.id.includes('deprecated')) {
         tab = `${tab}-deprecated`;
       }
     }
-
-    // if no dictionary entry exists, and tab data exists
-    if(componentTabs[entry.data.id] === undefined && tab) { 
-      componentTabs[entry.data.id] = [tab];
-    // if dictionary entry & tab data exists, and entry does not include tab
-    } else if (componentTabs[entry.data.id] && tab && !componentTabs[entry.data.id].includes(tab)) { 
-      componentTabs[entry.data.id] = [...componentTabs[entry.data.id], tab];
-    }
+    buildTab(entry, tab);
 
     return {
       params: { page: kebabCase(entry.data.id), section: entry.data.section, tab },
-      props: { entry, title: entry.data.title, component: entry.data.id,  package: entry.data.package },
+      props: { entry, ...entry.data },
     }
   })
 
-  const defaultOrder = 50;
-  const sourceOrder: any = {
-    react: 1,
-    'react-next': 1.1,
-    'react-demos': 2,
-    'react-deprecated': 2.1,
-    html: 3,
-    'html-demos': 4,
-    'design-guidelines': 99,
-    'accessibility': 100,
-    'upgrade-guide': 101,
-    'release-notes': 102,
-  };
-
-  const sortSources = (s1: string, s2: string) => {
-    const s1Index = sourceOrder[s1] || defaultOrder;
-    const s2Index = sourceOrder[s2] || defaultOrder;
-    if (s1Index === defaultOrder && s2Index === defaultOrder) {
-      return s1.localeCompare(s2);
-    }
-
-    return s1Index > s2Index ? 1 : -1;
-  }
-
-  // Sort tabs entries based on above sort order
-  // Ensures all tabs are displayed in a consistent order & which tab gets displayed for a component route without a tab 
-  Object.values(componentTabs).map((tabs: any) => {
-    tabs.sort(sortSources)
-  })
-
+  sortTabs() 
   return flatCol;
 }
 

--- a/src/pages/[section]/[page]/[...tab].astro
+++ b/src/pages/[section]/[page]/[...tab].astro
@@ -1,0 +1,97 @@
+---
+import { getCollection, render } from 'astro:content'
+import { Title, PageSection, Content as PFContent } from '@patternfly/react-core'
+import MainLayout from '../../../layouts/Main.astro'
+import { content } from "../../../content"
+import { kebabCase } from 'change-case'
+import { componentTabs, tabNameMapping } from '../../../globals';
+
+export async function getStaticPaths() {
+  const collections = await Promise.all(content.map(async (entry) => await getCollection(entry.name as 'textContent')))
+
+  const flatCol =  collections.flat().map((entry) => {
+    // if no dictionary entry exists, and tab data exists
+    if(componentTabs[entry.data.id] === undefined && entry.data.tab) { 
+      componentTabs[entry.data.id] = [entry.data.tab];
+    // if dictionary entry & tab data exists, and entry does not include tab
+    } else if (componentTabs[entry.data.id] && entry.data.tab && !componentTabs[entry.data.id].includes(entry.data.tab)) { 
+      componentTabs[entry.data.id] = [...componentTabs[entry.data.id], entry.data.tab];
+    }
+
+    return {
+      params: { page: kebabCase(entry.data.id), section: entry.data.section, tab: entry.data.tab },
+      props: { entry, title: entry.data.title, component: entry.data.id,  package: entry.data.package },
+    }
+  })
+
+  const defaultOrder = 50;
+  const sourceOrder: any = {
+    react: 1,
+    'react-next': 1.1,
+    'react-demos': 2,
+    'react-deprecated': 2.1,
+    html: 3,
+    'html-demos': 4,
+    'design-guidelines': 99,
+    'accessibility': 100,
+    'upgrade-guide': 101,
+    'release-notes': 102,
+  };
+
+  const sortSources = (s1: string, s2: string) => {
+    const s1Index = sourceOrder[s1] || defaultOrder;
+    const s2Index = sourceOrder[s2] || defaultOrder;
+    if (s1Index === defaultOrder && s2Index === defaultOrder) {
+      return s1.localeCompare(s2);
+    }
+
+    return s1Index > s2Index ? 1 : -1;
+  }
+
+  Object.values(componentTabs).map((tabs: any) => {
+    tabs.sort(sortSources)
+  })
+
+  return flatCol;
+}
+
+const { entry } = Astro.props
+const { title, id, section } = entry.data
+const { Content } = await render(entry)
+const currentPath = Astro.url.pathname;
+---
+
+<MainLayout>
+  {
+    title && (
+      <Title headingLevel="h1" size="4xl">
+        {title} 
+      </Title>
+    )
+  }
+  HELLO TAB 
+  <!-- {console.log(entry, id, componentTabs[id], currentPath)} -->
+  {componentTabs[id] && (
+    <PageSection id="ws-sticky-nav-tabs" stickyOnBreakpoint={{ default: 'top' }} type="tabs">
+      <div class="pf-v6-c-tabs pf-m-page-insets pf-m-no-border-bottom">
+        <ul class="pf-v6-c-tabs__list">
+          {componentTabs[id].map((tab: string, index: number) => ( // TODO: sort tabs array to standard
+            // eslint-disable-next-line react/jsx-key
+            <li
+              class={`pf-v6-c-tabs__item${currentPath === `/${section}/${kebabCase(id)}/${tab}` ? ' pf-m-current' : ''}`}
+            >
+              <a class="pf-v6-c-tabs__link" href={`/${section}/${kebabCase(id)}/${tab}`}>
+                {tabNameMapping[tab]}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </PageSection>
+  )}
+  <PageSection id="main-content" isFilled>
+    <PFContent>
+      <Content />
+    </PFContent>
+  </PageSection>
+</MainLayout>


### PR DESCRIPTION
WIP.

- Added tabs section to component tab page
- Added logic to `[...tab].astro` to build a tab dictionary from available routes (stored in `componentTabs`) and then sort the tabs in a specified order (from org repo). 
- Added [section] to determine if route is a component page
- Renamed [id] to [page] to distinguish from `entry.id` and `entry.data.id` fields
- Updated Nav logic to only show unique components (based on frontmatter `id`) & route to `/components/{kebab-component}`
- Updated `[...page].astro` to rewrite content to `[...tab].astro` for component pages (so that /component/alert effectively will show /component/alert/react). It should be picking the first available tab based on the `componentTabs` global.
- Updated `Page.astro`, removing the wrapping PF Content component (this was interfering with rendering the tabs classes)

Todos:
- back out content config changes & clean up comments