### PR TITLE
feat(CSSTable): Add CSS variable table

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -20,7 +20,7 @@ const config: Config = {
   },
   setupFilesAfterEnv: ['<rootDir>/test.setup.ts'],
   transformIgnorePatterns: [
-    '/node_modules/(?!(change-case|@?nanostores|react-docgen|strip-indent)/)',
+    '/node_modules/(?!(change-case|@?nanostores|react-docgen|strip-indent|@patternfly/react-icons)/)',
   ],
 }
 

--- a/src/components/AutoLinkHeader.tsx
+++ b/src/components/AutoLinkHeader.tsx
@@ -6,8 +6,8 @@ import { css } from '@patternfly/react-styles'
 interface AutoLinkHeaderProps extends React.HTMLProps<HTMLDivElement> {
   id?: string
   headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
-  children: React.ReactNode | string
-  metaText?: React.ReactNode | string
+  children: React.ReactNode
+  metaText?: React.ReactNode
   className?: string
 }
 

--- a/src/components/AutoLinkHeader.tsx
+++ b/src/components/AutoLinkHeader.tsx
@@ -1,0 +1,56 @@
+import { Flex, FlexItem, Content, Button } from '@patternfly/react-core'
+import LinkIcon from '@patternfly/react-icons/dist/esm/icons/link-icon'
+import { slugger } from '../utils/slugger'
+import { css } from '@patternfly/react-styles'
+
+interface AutoLinkHeaderProps extends React.HTMLProps<HTMLDivElement> {
+  id?: string
+  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  children: React.ReactNode | string
+  metaText?: React.ReactNode | string
+  className?: string
+}
+
+export const AutoLinkHeader = ({
+  id,
+  headingLevel,
+  children,
+  metaText,
+  className,
+}: AutoLinkHeaderProps) => {
+  const slug = id || slugger(children)
+
+  return (
+    <Flex
+      alignItems={{ default: 'alignItemsCenter' }}
+      spaceItems={{ default: 'spaceItemsSm' }}
+    >
+      <FlexItem>
+        <Content
+          id={slug}
+          component={headingLevel}
+          className={css('ws-heading', className)}
+          tabIndex={-1}
+          isEditorial
+        >
+          <Button
+            href={`#${slug}`}
+            component="a"
+            className="ws-heading-anchor"
+            tabIndex={-1}
+            aria-hidden
+            variant="plain"
+            isInline
+          >
+            <LinkIcon
+              className="ws-heading-anchor-icon"
+              style={{ verticalAlign: 'middle' }}
+            />
+          </Button>
+          {children}
+        </Content>
+      </FlexItem>
+      {metaText && <FlexItem>{metaText}</FlexItem>}
+    </Flex>
+  )
+}

--- a/src/components/CSSSearch.tsx
+++ b/src/components/CSSSearch.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { SearchInput } from '@patternfly/react-core'
+
+interface CSSSearchProps {
+  getDebouncedFilteredRows: (value: string) => void
+}
+
+export const CSSSearch: React.FC<CSSSearchProps> = ({
+  getDebouncedFilteredRows,
+}: CSSSearchProps) => {
+  const [filterValue, setFilterValue] = useState('')
+
+  const onFilterChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    value: string,
+  ) => {
+    setFilterValue(value)
+    getDebouncedFilteredRows(value)
+  }
+
+  return (
+    <SearchInput
+      aria-label="Filter CSS Variables"
+      placeholder="Filter CSS Variables"
+      value={filterValue}
+      onChange={onFilterChange}
+    />
+  )
+}

--- a/src/components/CSSSearch.tsx
+++ b/src/components/CSSSearch.tsx
@@ -3,10 +3,14 @@ import { SearchInput } from '@patternfly/react-core'
 
 interface CSSSearchProps {
   getDebouncedFilteredRows: (value: string) => void
+  'aria-label'?: string
+  placeholder?: string
 }
 
 export const CSSSearch: React.FC<CSSSearchProps> = ({
   getDebouncedFilteredRows,
+  'aria-label': ariaLabel = 'Filter CSS Variables',
+  placeholder = 'Filter CSS Variables',
 }: CSSSearchProps) => {
   const [filterValue, setFilterValue] = useState('')
 
@@ -20,8 +24,8 @@ export const CSSSearch: React.FC<CSSSearchProps> = ({
 
   return (
     <SearchInput
-      aria-label="Filter CSS Variables"
-      placeholder="Filter CSS Variables"
+      aria-label={ariaLabel}
+      placeholder={placeholder}
       value={filterValue}
       onChange={onFilterChange}
     />

--- a/src/components/CSSTable.astro
+++ b/src/components/CSSTable.astro
@@ -1,0 +1,11 @@
+---
+import { CSSTable as CSSTableComponent } from './CSSTable'
+
+const { cssPrefix } = Astro.props
+---
+
+{
+  cssPrefix?.map((prefix: string, index: number) => (
+    <CSSTableComponent key={index} cssPrefix={prefix} client:only="react" />
+  ))
+}

--- a/src/components/CSSTable.astro
+++ b/src/components/CSSTable.astro
@@ -1,11 +1,33 @@
 ---
 import { CSSTable as CSSTableComponent } from './CSSTable'
+import { AutoLinkHeader } from './AutoLinkHeader'
+import { Stack, StackItem } from '@patternfly/react-core'
 
 const { cssPrefix } = Astro.props
 ---
 
 {
-  cssPrefix?.map((prefix: string, index: number) => (
-    <CSSTableComponent key={index} cssPrefix={prefix} client:only="react" />
-  ))
+  cssPrefix?.length > 0 && (
+    <Stack hasGutter>
+      <StackItem>
+        <AutoLinkHeader
+          headingLevel="h2"
+          className="pf-v6-c-content--h2"
+          id="css-variables"
+        >
+          CSS variables
+        </AutoLinkHeader>
+      </StackItem>
+
+      {cssPrefix?.map((prefix: string, index: number) => (
+        <StackItem key={index}>
+          <CSSTableComponent
+            autoLinkHeader={cssPrefix.length > 1}
+            cssPrefix={prefix}
+            client:only="react"
+          />
+        </StackItem>
+      ))}
+    </Stack>
+  )
 }

--- a/src/components/CSSTable.astro
+++ b/src/components/CSSTable.astro
@@ -19,7 +19,7 @@ const { cssPrefix } = Astro.props
         </AutoLinkHeader>
       </StackItem>
 
-      {cssPrefix?.map((prefix: string, index: number) => (
+      {cssPrefix.map((prefix: string, index: number) => (
         <StackItem key={index}>
           <CSSTableComponent
             autoLinkHeader={cssPrefix.length > 1}

--- a/src/components/CSSTable.tsx
+++ b/src/components/CSSTable.tsx
@@ -1,0 +1,282 @@
+import { debounce, List, ListItem, Stack } from '@patternfly/react-core'
+import { Table, Thead, Th, Tr, Tbody, Td } from '@patternfly/react-table'
+import { useState } from 'react'
+import LevelUpAltIcon from '@patternfly/react-icons/dist/esm/icons/level-up-alt-icon'
+import * as tokensModule from '@patternfly/react-tokens/dist/esm/componentIndex'
+import React from 'react'
+import { CSSSearch } from './CSSSearch'
+
+export type ComponentProp = {
+  isOpen: boolean
+  cells: [
+    string,
+    {
+      type: string
+      key: string
+      ref: any
+      props: any
+    },
+  ]
+  details: {
+    parent: number
+    fullWidth: boolean
+    data: any
+  }
+}
+
+type Value = {
+  name: string
+  value: string
+  values?: string[]
+}
+
+type FileList = {
+  [key: string]: {
+    name: string
+    value: string
+    values?: Value[]
+  }
+}
+
+type List = {
+  selector: string
+  property: string
+  token: string
+  value: string
+  values?: string[]
+}
+
+type FilteredRows = {
+  cells: (React.ReactNode | string | string[])[]
+  isOpen?: boolean
+  details?: { parent: number; fullWidth: boolean; data: React.ReactNode }
+}
+
+interface CSSTableProps extends React.HTMLProps<HTMLDivElement> {
+  cssPrefix: string
+  headingLevel?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+  hideSelectorColumn?: boolean
+  selector?: string
+}
+
+const isColorRegex = /^(#|rgb)/
+const mappingAsList = (property: string, values: string[]) => (
+  <List isPlain>
+    <ListItem>{property}</ListItem>
+    {values.map((entry: string) => (
+      <ListItem key={entry} icon={<LevelUpAltIcon className="rotate-90-deg" />}>
+        {entry}
+      </ListItem>
+    ))}
+  </List>
+)
+
+const flattenList = (files: FileList[]) => {
+  const list = [] as List[]
+  files.forEach((file) => {
+    Object.entries(file).forEach(([selector, values]) => {
+      if (values !== undefined) {
+        Object.entries(values).forEach(([key, val]) => {
+          if (typeof val === 'object' && val !== null && 'name' in val) {
+            const v = val as unknown as Value
+            list.push({
+              selector,
+              property: v.name,
+              token: key,
+              value: v.value,
+              values: v.values,
+            })
+          }
+        })
+      }
+    })
+  })
+  return list
+}
+
+export const CSSTable: React.FunctionComponent<CSSTableProps> = ({
+  cssPrefix,
+  headingLevel = 'h3',
+  hideSelectorColumn = false,
+  selector,
+}) => {
+  const prefixToken = cssPrefix.replace('pf-v6-', '').replace(/-+/g, '_')
+
+  const applicableFiles = Object.entries(tokensModule)
+    .filter(([key, _val]) => prefixToken === key)
+    .sort(([key1], [key2]) => key1.localeCompare(key2))
+    .map(([_key, val]) => {
+      if (selector) {
+        return {
+          selector: (val as Record<string, any>)[selector],
+        }
+      }
+      return val
+    })
+
+  const flatList = flattenList(applicableFiles as any)
+
+  const getFilteredRows = (searchRE?: RegExp) => {
+    const newFilteredRows = [] as FilteredRows[]
+    let rowNumber = -1
+    flatList.forEach((row) => {
+      const { selector, property, value, values } = row
+      const passes =
+        !searchRE ||
+        searchRE.test(selector) ||
+        searchRE.test(property) ||
+        searchRE.test(value) ||
+        (values && searchRE.test(JSON.stringify(values)))
+      if (passes) {
+        const rowKey = `${selector}_${property}`
+        const isColor = isColorRegex.test(value)
+        const cells = [
+          hideSelectorColumn ? [] : [selector],
+          property,
+          <div key={rowKey}>
+            <div
+              key={`${rowKey}_1`}
+              className="pf-v6-l-flex pf-m-space-items-sm"
+            >
+              {isColor && (
+                <div
+                  key={`${rowKey}_2`}
+                  className="pf-v6-l-flex pf-m-column pf-m-align-self-center"
+                >
+                  <span
+                    className="circle"
+                    style={{ backgroundColor: `${value}` }}
+                  />
+                </div>
+              )}
+              <div
+                key={`${rowKey}_3`}
+                className="pf-v6-l-flex pf-m-column pf-m-align-self-center ws-td-text"
+              >
+                {isColor && '(In light theme)'} {value}
+              </div>
+            </div>
+          </div>,
+        ]
+        newFilteredRows.push({
+          isOpen: values ? false : undefined,
+          cells,
+          details: values
+            ? {
+                parent: rowNumber,
+                fullWidth: true,
+                data: mappingAsList(property, values),
+              }
+            : undefined,
+        })
+        rowNumber += 1
+        if (values) {
+          rowNumber += 1
+        }
+      }
+    })
+    return newFilteredRows
+  }
+
+  const INITIAL_REGEX = /.*/
+  const [searchRE, setSearchRE] = useState<RegExp>(INITIAL_REGEX)
+  const [rows, setRows] = useState(getFilteredRows(searchRE))
+
+  const SectionHeading = headingLevel
+  //const publicProps = componentProps?.filter((prop) => !prop.isHidden)
+  const hasPropsToRender = !(typeof cssPrefix === 'undefined')
+
+  const onCollapse = (
+    _event: React.MouseEvent,
+    rowKey: number,
+    isOpen: boolean,
+  ) => {
+    const collapseAll = rowKey === undefined
+    let newRows = Array.from(rows)
+
+    if (collapseAll) {
+      newRows = newRows.map((r) =>
+        r.isOpen === undefined ? r : { ...r, isOpen },
+      )
+    } else {
+      newRows[rowKey] = { ...newRows[rowKey], isOpen }
+    }
+    setRows(newRows)
+  }
+
+  const getDebouncedFilteredRows = debounce((value) => {
+    const newSearchRE = new RegExp(value, 'i')
+    setSearchRE(newSearchRE)
+    setRows(getFilteredRows(newSearchRE))
+  }, 500)
+
+  return (
+    <div>
+      <SectionHeading>CSS variables</SectionHeading>
+      <Stack hasGutter>
+        {hasPropsToRender && (
+          <>
+            <CSSSearch getDebouncedFilteredRows={getDebouncedFilteredRows} />
+            <Table
+              variant="compact"
+              aria-label={`CSS Variables prefixed with ${cssPrefix}`}
+            >
+              <Thead>
+                <Tr>
+                  {!hideSelectorColumn && (
+                    <React.Fragment>
+                      <Th screenReaderText="Expand or collapse column" />
+                      <Th>Selector</Th>
+                    </React.Fragment>
+                  )}
+                  <Th>Variable</Th>
+                  <Th>Value</Th>
+                </Tr>
+              </Thead>
+              {!hideSelectorColumn ? (
+                rows.map((row, rowIndex: number) => (
+                  <Tbody key={rowIndex} isExpanded={row.isOpen}>
+                    <Tr>
+                      <Td
+                        expand={
+                          row.details
+                            ? {
+                                rowIndex,
+                                isExpanded: row.isOpen || false,
+                                onToggle: onCollapse,
+                                expandId: `css-vars-expandable-toggle-${cssPrefix}`,
+                              }
+                            : undefined
+                        }
+                      />
+                      <Td dataLabel="Selector">{row.cells[0]}</Td>
+                      <Td dataLabel="Variable">{row.cells[1]}</Td>
+                      <Td dataLabel="Value">{row.cells[2]}</Td>
+                    </Tr>
+                    {row.details ? (
+                      <Tr isExpanded={row.isOpen}>
+                        {!row.details.fullWidth ? <Td /> : null}
+                        <Td dataLabel="Selector" colSpan={5}>
+                          {row.details.data}
+                        </Td>
+                      </Tr>
+                    ) : null}
+                  </Tbody>
+                ))
+              ) : (
+                <Tbody>
+                  {rows.map((row, rowIndex: number) => (
+                    <Tr key={rowIndex}>
+                      <Td dataLabel="Variable">{row.cells[0]}</Td>
+                      <Td dataLabel="Value">{row.cells[1]}</Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              )}
+            </Table>
+          </>
+        )}
+      </Stack>
+    </div>
+  )
+}

--- a/src/components/__tests__/CSSTable.test.tsx
+++ b/src/components/__tests__/CSSTable.test.tsx
@@ -88,6 +88,7 @@ it('does not render the "Prefixed with" header when autoLinkHeader is false (def
 })
 
 it('filters rows based on search input', async () => {
+  userEvent.setup()
   render(<CSSTable cssPrefix="pf-v6-test" debounceLength={0} />)
   const searchInput = screen.getByPlaceholderText('Filter CSS Variables')
 

--- a/src/components/__tests__/CSSTable.test.tsx
+++ b/src/components/__tests__/CSSTable.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CSSTable } from '../CSSTable'
+
+jest.mock('@patternfly/react-tokens/dist/esm/componentIndex', () => ({
+  test: {
+    '.test-selector': {
+      '--test-property': {
+        name: 'test-property',
+        value: 'test-value',
+      },
+      '--another-property': {
+        name: 'another-property',
+        value: '#123456',
+      },
+    },
+    '.another-selector': {
+      '--list-property': {
+        name: 'list-property',
+        value: 'list-item-1',
+        values: ['list-item-1', 'list-item-2'],
+      },
+    },
+  },
+  'pf-v6-empty': {},
+}))
+
+describe('<CSSTable />', () => {
+  it('renders without crashing', () => {
+    render(<CSSTable cssPrefix="pf-v6-test" />)
+    expect(
+      screen.getByRole('grid', {
+        name: /CSS Variables prefixed with pf-v6-test/i,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the correct table headers when hideSelectorColumn is false (default)', () => {
+    render(<CSSTable cssPrefix="pf-v6-test" />)
+    expect(screen.getByText('Selector')).toBeInTheDocument()
+    expect(screen.getByText('Variable')).toBeInTheDocument()
+    expect(screen.getByText('Value')).toBeInTheDocument()
+  })
+
+  it('renders the correct table headers when hideSelectorColumn is true', () => {
+    render(<CSSTable cssPrefix="pf-v6-test" hideSelectorColumn />)
+    expect(screen.queryByText('Selector')).not.toBeInTheDocument()
+    expect(screen.getByText('Variable')).toBeInTheDocument()
+    expect(screen.getByText('Value')).toBeInTheDocument()
+  })
+
+  it('renders the correct data rows', () => {
+    render(<CSSTable cssPrefix="pf-v6-test" />)
+    expect(
+      screen.getByRole('row', {
+        name: '.test-selector test-property test-value',
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('row', {
+        name: '.test-selector another-property (In light theme) #123456',
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('row', {
+        name: 'Details .another-selector list-property list-item-1',
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('renders the "Prefixed with" header when autoLinkHeader is true', () => {
+    render(<CSSTable cssPrefix="pf-v6-test" autoLinkHeader />)
+    expect(
+      screen.getByRole('heading', {
+        name: /Prefixed with 'pf-v6-test'/i,
+        level: 3,
+      }),
+    ).toBeInTheDocument()
+  })
+
+  it('does not render the "Prefixed with" header when autoLinkHeader is false (default)', () => {
+    render(<CSSTable cssPrefix="pf-v6-test" />)
+    expect(
+      screen.queryByRole('heading', {
+        name: /Prefixed with 'pf-v6-test'/i,
+        level: 3,
+      }),
+    ).not.toBeInTheDocument()
+  })
+
+  it('filters rows based on search input', async () => {
+    render(<CSSTable cssPrefix="pf-v6-test" debounceLength={0} />)
+    const searchInput = screen.getByPlaceholderText('Filter CSS Variables')
+
+    expect(
+      screen.getByRole('row', {
+        name: '.test-selector test-property test-value',
+      }),
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('row', {
+        name: 'Details .another-selector list-property list-item-1',
+      }),
+    ).toBeInTheDocument()
+    fireEvent.change(searchInput, { target: { value: 'test' } })
+    await waitFor(() => {
+      // row doesn't seem to work here for whatever reason
+      expect(screen.getAllByText('.test-selector')).toHaveLength(2)
+      expect(screen.getByText('test-property')).toBeInTheDocument()
+      expect(screen.queryByText('.another-selector')).not.toBeInTheDocument()
+      expect(screen.queryByText('list-property')).not.toBeInTheDocument()
+    })
+
+    fireEvent.change(searchInput, { target: { value: 'list' } })
+    await waitFor(() => {
+      expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
+      expect(screen.queryByText('test-property')).not.toBeInTheDocument()
+      expect(screen.getByText('.another-selector')).toBeInTheDocument()
+      expect(screen.getAllByText('list-property')).toHaveLength(2)
+    })
+  })
+
+  it('handles the case where the cssPrefix does not exist in tokensModule', () => {
+    render(<CSSTable cssPrefix="pf-v6-nonexistent" />)
+    expect(screen.queryByRole('grid')).toBeInTheDocument() // Table should still render, but be empty
+    expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
+  })
+
+  it('renders correctly when hideSelectorColumn is true and there are rows', () => {
+    render(<CSSTable cssPrefix="pf-v6-test" hideSelectorColumn />)
+    expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
+    expect(
+      screen.getByRole('row', {
+        name: 'test-property',
+      }),
+    ).toBeInTheDocument()
+  })
+})

--- a/src/components/__tests__/CSSTable.test.tsx
+++ b/src/components/__tests__/CSSTable.test.tsx
@@ -88,7 +88,7 @@ it('does not render the "Prefixed with" header when autoLinkHeader is false (def
 })
 
 it('filters rows based on search input', async () => {
-  userEvent.setup()
+  const user = userEvent.setup()
   render(<CSSTable cssPrefix="pf-v6-test" debounceLength={0} />)
   const searchInput = screen.getByPlaceholderText('Filter CSS Variables')
 
@@ -103,7 +103,7 @@ it('filters rows based on search input', async () => {
     }),
   ).toBeInTheDocument()
 
-  await userEvent.type(searchInput, 'test')
+  await user.type(searchInput, 'test')
   await waitFor(() => {
     // row doesn't seem to work here for whatever reason
     expect(screen.getAllByText('.test-selector')).toHaveLength(2)
@@ -112,8 +112,8 @@ it('filters rows based on search input', async () => {
     expect(screen.queryByText('list-property')).not.toBeInTheDocument()
   })
 
-  await userEvent.clear(searchInput)
-  await userEvent.type(searchInput, 'list')
+  await user.clear(searchInput)
+  await user.type(searchInput, 'list')
   await waitFor(() => {
     expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
     expect(screen.queryByText('test-property')).not.toBeInTheDocument()

--- a/src/components/__tests__/CSSTable.test.tsx
+++ b/src/components/__tests__/CSSTable.test.tsx
@@ -1,5 +1,6 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { CSSTable } from '../CSSTable'
+import userEvent from '@testing-library/user-event'
 
 jest.mock('@patternfly/react-tokens/dist/esm/componentIndex', () => ({
   test: {
@@ -24,114 +25,114 @@ jest.mock('@patternfly/react-tokens/dist/esm/componentIndex', () => ({
   'pf-v6-empty': {},
 }))
 
-describe('<CSSTable />', () => {
-  it('renders without crashing', () => {
-    render(<CSSTable cssPrefix="pf-v6-test" />)
-    expect(
-      screen.getByRole('grid', {
-        name: /CSS Variables prefixed with pf-v6-test/i,
-      }),
-    ).toBeInTheDocument()
+it('renders without crashing', () => {
+  render(<CSSTable cssPrefix="pf-v6-test" />)
+  expect(
+    screen.getByRole('grid', {
+      name: /CSS Variables prefixed with pf-v6-test/i,
+    }),
+  ).toBeInTheDocument()
+})
+
+it('renders the correct table headers when hideSelectorColumn is false (default)', () => {
+  render(<CSSTable cssPrefix="pf-v6-test" />)
+  expect(screen.getByText('Selector')).toBeInTheDocument()
+  expect(screen.getByText('Variable')).toBeInTheDocument()
+  expect(screen.getByText('Value')).toBeInTheDocument()
+})
+
+it('renders the correct table headers when hideSelectorColumn is true', () => {
+  render(<CSSTable cssPrefix="pf-v6-test" hideSelectorColumn />)
+  expect(screen.queryByText('Selector')).not.toBeInTheDocument()
+  expect(screen.getByText('Variable')).toBeInTheDocument()
+  expect(screen.getByText('Value')).toBeInTheDocument()
+})
+
+it('renders the correct data rows', () => {
+  render(<CSSTable cssPrefix="pf-v6-test" />)
+  expect(
+    screen.getByRole('row', {
+      name: '.test-selector test-property test-value',
+    }),
+  ).toBeInTheDocument()
+  expect(
+    screen.getByRole('row', {
+      name: '.test-selector another-property (In light theme) #123456',
+    }),
+  ).toBeInTheDocument()
+  expect(
+    screen.getByRole('row', {
+      name: 'Details .another-selector list-property list-item-1',
+    }),
+  ).toBeInTheDocument()
+})
+
+it('renders the "Prefixed with" header when autoLinkHeader is true', () => {
+  render(<CSSTable cssPrefix="pf-v6-test" autoLinkHeader />)
+  expect(
+    screen.getByRole('heading', {
+      name: /Prefixed with 'pf-v6-test'/i,
+      level: 3,
+    }),
+  ).toBeInTheDocument()
+})
+
+it('does not render the "Prefixed with" header when autoLinkHeader is false (default)', () => {
+  render(<CSSTable cssPrefix="pf-v6-test" />)
+  expect(
+    screen.queryByRole('heading', {
+      name: /Prefixed with 'pf-v6-test'/i,
+      level: 3,
+    }),
+  ).not.toBeInTheDocument()
+})
+
+it('filters rows based on search input', async () => {
+  render(<CSSTable cssPrefix="pf-v6-test" debounceLength={0} />)
+  const searchInput = screen.getByPlaceholderText('Filter CSS Variables')
+
+  expect(
+    screen.getByRole('row', {
+      name: '.test-selector test-property test-value',
+    }),
+  ).toBeInTheDocument()
+  expect(
+    screen.getByRole('row', {
+      name: 'Details .another-selector list-property list-item-1',
+    }),
+  ).toBeInTheDocument()
+
+  await userEvent.type(searchInput, 'test')
+  await waitFor(() => {
+    // row doesn't seem to work here for whatever reason
+    expect(screen.getAllByText('.test-selector')).toHaveLength(2)
+    expect(screen.getByText('test-property')).toBeInTheDocument()
+    expect(screen.queryByText('.another-selector')).not.toBeInTheDocument()
+    expect(screen.queryByText('list-property')).not.toBeInTheDocument()
   })
 
-  it('renders the correct table headers when hideSelectorColumn is false (default)', () => {
-    render(<CSSTable cssPrefix="pf-v6-test" />)
-    expect(screen.getByText('Selector')).toBeInTheDocument()
-    expect(screen.getByText('Variable')).toBeInTheDocument()
-    expect(screen.getByText('Value')).toBeInTheDocument()
-  })
-
-  it('renders the correct table headers when hideSelectorColumn is true', () => {
-    render(<CSSTable cssPrefix="pf-v6-test" hideSelectorColumn />)
-    expect(screen.queryByText('Selector')).not.toBeInTheDocument()
-    expect(screen.getByText('Variable')).toBeInTheDocument()
-    expect(screen.getByText('Value')).toBeInTheDocument()
-  })
-
-  it('renders the correct data rows', () => {
-    render(<CSSTable cssPrefix="pf-v6-test" />)
-    expect(
-      screen.getByRole('row', {
-        name: '.test-selector test-property test-value',
-      }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('row', {
-        name: '.test-selector another-property (In light theme) #123456',
-      }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('row', {
-        name: 'Details .another-selector list-property list-item-1',
-      }),
-    ).toBeInTheDocument()
-  })
-
-  it('renders the "Prefixed with" header when autoLinkHeader is true', () => {
-    render(<CSSTable cssPrefix="pf-v6-test" autoLinkHeader />)
-    expect(
-      screen.getByRole('heading', {
-        name: /Prefixed with 'pf-v6-test'/i,
-        level: 3,
-      }),
-    ).toBeInTheDocument()
-  })
-
-  it('does not render the "Prefixed with" header when autoLinkHeader is false (default)', () => {
-    render(<CSSTable cssPrefix="pf-v6-test" />)
-    expect(
-      screen.queryByRole('heading', {
-        name: /Prefixed with 'pf-v6-test'/i,
-        level: 3,
-      }),
-    ).not.toBeInTheDocument()
-  })
-
-  it('filters rows based on search input', async () => {
-    render(<CSSTable cssPrefix="pf-v6-test" debounceLength={0} />)
-    const searchInput = screen.getByPlaceholderText('Filter CSS Variables')
-
-    expect(
-      screen.getByRole('row', {
-        name: '.test-selector test-property test-value',
-      }),
-    ).toBeInTheDocument()
-    expect(
-      screen.getByRole('row', {
-        name: 'Details .another-selector list-property list-item-1',
-      }),
-    ).toBeInTheDocument()
-    fireEvent.change(searchInput, { target: { value: 'test' } })
-    await waitFor(() => {
-      // row doesn't seem to work here for whatever reason
-      expect(screen.getAllByText('.test-selector')).toHaveLength(2)
-      expect(screen.getByText('test-property')).toBeInTheDocument()
-      expect(screen.queryByText('.another-selector')).not.toBeInTheDocument()
-      expect(screen.queryByText('list-property')).not.toBeInTheDocument()
-    })
-
-    fireEvent.change(searchInput, { target: { value: 'list' } })
-    await waitFor(() => {
-      expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
-      expect(screen.queryByText('test-property')).not.toBeInTheDocument()
-      expect(screen.getByText('.another-selector')).toBeInTheDocument()
-      expect(screen.getAllByText('list-property')).toHaveLength(2)
-    })
-  })
-
-  it('handles the case where the cssPrefix does not exist in tokensModule', () => {
-    render(<CSSTable cssPrefix="pf-v6-nonexistent" />)
-    expect(screen.queryByRole('grid')).toBeInTheDocument() // Table should still render, but be empty
+  await userEvent.clear(searchInput)
+  await userEvent.type(searchInput, 'list')
+  await waitFor(() => {
     expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
+    expect(screen.queryByText('test-property')).not.toBeInTheDocument()
+    expect(screen.getByText('.another-selector')).toBeInTheDocument()
+    expect(screen.getAllByText('list-property')).toHaveLength(2)
   })
+})
 
-  it('renders correctly when hideSelectorColumn is true and there are rows', () => {
-    render(<CSSTable cssPrefix="pf-v6-test" hideSelectorColumn />)
-    expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
-    expect(
-      screen.getByRole('row', {
-        name: 'test-property',
-      }),
-    ).toBeInTheDocument()
-  })
+it('handles the case where the cssPrefix does not exist in tokensModule', () => {
+  render(<CSSTable cssPrefix="pf-v6-nonexistent" />)
+  expect(screen.queryByRole('grid')).toBeInTheDocument() // Table should still render, but be empty
+  expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
+})
+
+it('renders correctly when hideSelectorColumn is true and there are rows', () => {
+  render(<CSSTable cssPrefix="pf-v6-test" hideSelectorColumn />)
+  expect(screen.queryByText('.test-selector')).not.toBeInTheDocument()
+  expect(
+    screen.getByRole('row', {
+      name: 'test-property',
+    }),
+  ).toBeInTheDocument()
 })

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -17,8 +17,8 @@ function defineContent(contentObj: CollectionDefinition) {
   // TODO: Expand for other packages that remain under the react umbrella (Table, CodeEditor, etc)
   const tabMap: any = {
     'react-component-docs': 'react',
-    'core-component-docs': 'html' 
-  };
+    'core-component-docs': 'html',
+  }
 
   return defineCollection({
     loader: glob({ base: dir, pattern }),
@@ -28,7 +28,18 @@ function defineContent(contentObj: CollectionDefinition) {
       subsection: z.string().optional(),
       title: z.string().optional(),
       propComponents: z.array(z.string()).optional(),
-      tab: z.string().optional().default(tabMap[name])
+      tab: z.string().optional().default(tabMap[name]),
+      cssPrefix: z
+        .preprocess((val) => {
+          if (typeof val === 'string') {
+            return [val]
+          }
+          if (Array.isArray(val)) {
+            return val
+          }
+          return undefined
+        }, z.array(z.string()))
+        .optional(),
     }),
   })
 }

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -30,15 +30,11 @@ function defineContent(contentObj: CollectionDefinition) {
       propComponents: z.array(z.string()).optional(),
       tab: z.string().optional().default(tabMap[name]),
       cssPrefix: z
-        .preprocess((val) => {
-          if (typeof val === 'string') {
-            return [val]
-          }
-          if (Array.isArray(val)) {
-            return val
-          }
-          return undefined
-        }, z.array(z.string()))
+        .union([
+          z.string().transform((val) => [val]),
+          z.array(z.string()),
+          z.null().transform(() => undefined),
+        ])
         .optional(),
     }),
   })

--- a/src/layouts/Main.astro
+++ b/src/layouts/Main.astro
@@ -1,11 +1,11 @@
 ---
 import '@patternfly/patternfly/patternfly.css'
+import '../styles/global.scss'
 import { ClientRouter } from 'astro:transitions'
 
 import Page from '../components/Page.astro'
 import Masthead from '../components/Masthead.astro'
 import Navigation from '../components/Navigation.astro'
-
 ---
 
 <html lang="en" transition:animate="none">
@@ -27,11 +27,15 @@ import Navigation from '../components/Navigation.astro'
 </html>
 
 <script>
-  const themePreference = window.localStorage.getItem ('theme-preference');
-  document?.querySelector('html')?.classList.toggle('pf-v6-theme-dark', themePreference === 'dark' ); 
-  
-  document.addEventListener("astro:after-swap", () => {
-      const themePreference = window.localStorage.getItem ('theme-preference');
-      document?.querySelector('html')?.classList.toggle('pf-v6-theme-dark', themePreference === 'dark' ); 
-  });
+  const themePreference = window.localStorage.getItem('theme-preference')
+  document
+    ?.querySelector('html')
+    ?.classList.toggle('pf-v6-theme-dark', themePreference === 'dark')
+
+  document.addEventListener('astro:after-swap', () => {
+    const themePreference = window.localStorage.getItem('theme-preference')
+    document
+      ?.querySelector('html')
+      ?.classList.toggle('pf-v6-theme-dark', themePreference === 'dark')
+  })
 </script>

--- a/src/pages/[section]/[...page].astro
+++ b/src/pages/[section]/[...page].astro
@@ -6,6 +6,7 @@ import { content } from '../../content'
 import { kebabCase } from 'change-case'
 import { componentTabs } from '../../globals'
 import PropsTables from '../../components/PropsTables.astro'
+import CSSTable from '../../components/CSSTable.astro'
 
 export async function getStaticPaths() {
   const collections = await Promise.all(
@@ -20,16 +21,18 @@ export async function getStaticPaths() {
       entry,
       title: entry.data.title,
       propComponents: entry.data.propComponents,
+      cssPrefix: entry.data.cssPrefix,
     },
   }))
 }
 
-const { entry, propComponents } = Astro.props
+const { entry, propComponents, cssPrefix } = Astro.props
 const { title, id, section } = entry.data
 const { Content } = await render(entry)
 
-if(section === 'components') { // if section is components, rewrite to first tab content
-  return Astro.rewrite(`/components/${kebabCase(id)}/${componentTabs[id][0]}`);
+if (section === 'components') {
+  // if section is components, rewrite to first tab content
+  return Astro.rewrite(`/components/${kebabCase(id)}/${componentTabs[id][0]}`)
 }
 ---
 
@@ -37,10 +40,11 @@ if(section === 'components') { // if section is components, rewrite to first tab
   {
     title && (
       <Title headingLevel="h1" size="4xl">
-        {title} 
+        {title}
       </Title>
     )
   }
   <Content />
   <PropsTables propComponents={propComponents} server:defer />
+  <CSSTable cssPrefix={cssPrefix} server:defer />
 </MainLayout>

--- a/src/pages/[section]/[...page].astro
+++ b/src/pages/[section]/[...page].astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection, render } from 'astro:content'
-import { Title } from '@patternfly/react-core'
+import { Title, Stack, StackItem } from '@patternfly/react-core'
 import MainLayout from '../../layouts/Main.astro'
 import { content } from '../../content'
 import { kebabCase } from 'change-case'
@@ -45,6 +45,12 @@ if (section === 'components') {
     )
   }
   <Content />
-  <PropsTables propComponents={propComponents} server:defer />
-  <CSSTable cssPrefix={cssPrefix} server:defer />
+  <Stack hasGutter>
+    <StackItem>
+      <PropsTables propComponents={propComponents} server:defer />
+    </StackItem>
+    <StackItem>
+      <CSSTable cssPrefix={cssPrefix} server:defer />
+    </StackItem>
+  </Stack>
 </MainLayout>

--- a/src/pages/[section]/[page]/[...tab].astro
+++ b/src/pages/[section]/[page]/[...tab].astro
@@ -1,12 +1,6 @@
 ---
 import { getCollection, render } from 'astro:content'
-import {
-  Title,
-  PageSection,
-  Content as PFContent,
-  Stack,
-  StackItem,
-} from '@patternfly/react-core'
+import { Title, PageSection, Stack, StackItem } from '@patternfly/react-core'
 import MainLayout from '../../../layouts/Main.astro'
 import { content } from '../../../content'
 import { kebabCase } from 'change-case'

--- a/src/pages/[section]/[page]/[...tab].astro
+++ b/src/pages/[section]/[page]/[...tab].astro
@@ -4,6 +4,8 @@ import {
   Title,
   PageSection,
   Content as PFContent,
+  Stack,
+  StackItem,
 } from '@patternfly/react-core'
 import MainLayout from '../../../layouts/Main.astro'
 import { content } from '../../../content'
@@ -133,7 +135,13 @@ const currentPath = Astro.url.pathname
         LiveExample,
       }}
     />
-    <PropsTables propComponents={propComponents} server:defer />
-    <CSSTable cssPrefix={cssPrefix} server:defer />
+    <Stack hasGutter>
+      <StackItem>
+        <PropsTables propComponents={propComponents} server:defer />
+      </StackItem>
+      <StackItem>
+        <CSSTable cssPrefix={cssPrefix} server:defer />
+      </StackItem>
+    </Stack>
   </PageSection>
 </MainLayout>

--- a/src/pages/[section]/[page]/[...tab].astro
+++ b/src/pages/[section]/[page]/[...tab].astro
@@ -1,6 +1,10 @@
 ---
 import { getCollection, render } from 'astro:content'
-import { Title, PageSection } from '@patternfly/react-core'
+import {
+  Title,
+  PageSection,
+  Content as PFContent,
+} from '@patternfly/react-core'
 import MainLayout from '../../../layouts/Main.astro'
 import { content } from '../../../content'
 import { kebabCase } from 'change-case'
@@ -27,6 +31,7 @@ import {
   dd,
 } from '../../../components/Content'
 import LiveExample from '../../../components/LiveExample.astro'
+import CSSTable from '../../../components/CSSTable.astro'
 
 export async function getStaticPaths() {
   const collections = await Promise.all(
@@ -62,7 +67,8 @@ export async function getStaticPaths() {
   return flatCol
 }
 
-const { entry, propComponents } = Astro.props
+const { entry, propComponents, cssPrefix } = Astro.props
+
 const { title, id, section } = entry.data
 const { Content } = await render(entry)
 const currentPath = Astro.url.pathname
@@ -128,5 +134,6 @@ const currentPath = Astro.url.pathname
       }}
     />
     <PropsTables propComponents={propComponents} server:defer />
+    <CSSTable cssPrefix={cssPrefix} server:defer />
   </PageSection>
 </MainLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,4 @@
 ---
-import '../styles/global.scss'
 import MainLayout from '../layouts/Main.astro'
 ---
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -1,1 +1,13 @@
-// custom global scss would go here
+.circle {
+  height: 1em;
+  display: inline-block;
+  aspect-ratio: 1 / 1;
+  border-radius: 50%;
+  border: var(--pf-t--global--border--width--regular) solid
+    var(--pf-t--global--background--color--inverse--default);
+  box-shadow: var(--pf-t--global--box-shadow--sm);
+}
+
+.rotate-90-deg {
+  transform: rotate(90deg);
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -8,6 +8,36 @@
   box-shadow: var(--pf-t--global--box-shadow--sm);
 }
 
-.rotate-90-deg {
-  transform: rotate(90deg);
+.ws-heading {
+  position: relative;
+}
+
+.ws-heading-anchor {
+  color: var(--pf-t--global--icon--color--regular);
+  transform: translate(calc(-100% - var(--pf-t--global--spacer--xs)), -50%);
+  opacity: 0;
+  position: absolute;
+  left: 0;
+  top: 50%;
+  --pf-v6-c-content--a--Color: var(--pf-t--global--icon--color--regular);
+  --pf-v6-c-button--m-plain--PaddingInlineEnd: 0;
+  --pf-v6-c-button--m-plain--PaddingInlineStart: 0;
+  --pf-v6-c-button--MinWidth: unset;
+}
+
+.ws-heading-anchor.pf-v6-c-button:hover,
+.ws-heading-anchor.pf-v6-c-button:focus {
+  --pf-v6-c-button--hover--Color: var(--pf-t--global--icon--color--regular);
+  --pf-v6-c-button--BackgroundColor: transparent;
+  --pf-v6-c-content--a--hover--Color: var(--pf-t--global--icon--color--regular);
+}
+
+.ws-heading-anchor-icon {
+  height: 0.75rem;
+  width: 0.75rem;
+}
+
+.ws-heading:hover .ws-heading-anchor,
+.ws-heading-anchor:focus {
+  opacity: 1;
 }

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -8,6 +8,10 @@
   box-shadow: var(--pf-t--global--box-shadow--sm);
 }
 
+.rotate-90-deg {
+  transform: rotate(90deg);
+}
+
 .ws-heading {
   position: relative;
 }

--- a/src/utils/__tests__/slugger.test.tsx
+++ b/src/utils/__tests__/slugger.test.tsx
@@ -1,0 +1,26 @@
+import { slugger } from '../slugger'
+
+test('slugger', () => {
+  expect(slugger("Prefixed with 'pf-v6-c-alert-group'")).toBe(
+    'prefixed-with-pf-v6-c-alert-group',
+  )
+  expect(slugger(' has outer spaces ')).toBe('has-outer-spaces')
+  expect(slugger('Multiple  spaces')).toBe('multiple--spaces')
+  expect(slugger('MiXeD CaSe')).toBe('mixed-case')
+  expect(slugger('!@#$%^&*()')).toBe('')
+  expect(slugger('with~tilda')).toBe('with~tilda')
+  expect(slugger('with !@# special')).toBe('with--special')
+  expect(slugger('page index')).toBe('page-')
+  expect(slugger('index')).toBe('')
+  expect(slugger('index page')).toBe('index-page')
+  expect(slugger('')).toBe('')
+  expect(slugger(null)).toBe('')
+  expect(slugger(undefined)).toBe('')
+  expect(slugger(0)).toBe('0')
+  expect(slugger([])).toBe('')
+  expect(slugger(true)).toBe('')
+  expect(slugger(false)).toBe('')
+  expect(slugger(<span>React component</span>)).toBe('')
+  expect(slugger(<span></span>)).toBe('')
+  expect(slugger([<span key="0">1</span>, <span key="1">2</span>])).toBe('')
+})

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './capitalize'
+export * from './slugger'

--- a/src/utils/slugger.ts
+++ b/src/utils/slugger.ts
@@ -2,7 +2,9 @@ import React from 'react'
 
 // Should produce valid URLs and valid CSS ids
 export const slugger = (children: React.ReactNode) => {
-  const value = React.Children.toArray(children).join('')
+  const value = React.Children.toArray(children)
+    .filter((child) => typeof child === 'string' || typeof child === 'number')
+    .join('')
   return value
     .toLowerCase()
     .trim()

--- a/src/utils/slugger.ts
+++ b/src/utils/slugger.ts
@@ -1,0 +1,12 @@
+import React from 'react'
+
+// Should produce valid URLs and valid CSS ids
+export const slugger = (children: React.ReactNode) => {
+  const value = React.Children.toArray(children).join('')
+  return value
+    .toLowerCase()
+    .trim()
+    .replace(/index$/, '')
+    .replace(/\s/g, '-')
+    .replace(/[^A-Za-z0-9.\-~]/g, '')
+}

--- a/textContent/contribute.md
+++ b/textContent/contribute.md
@@ -3,12 +3,14 @@ id: Contribute
 title: Contribute to PatternFly
 section: get-started
 propComponents: ['Button', 'BadgeCountObject']
+cssPrefix: pf-v6-c-about-modal-box
 ---
 
-## Community contributions 
+## Community contributions
 
-Thank you for your interest in contributing to PatternFly! We depend on community contributions to help our design system grow and evolve. We encourage everyone, regardless of background, to get involved. Common contributions include (but aren't limited to): 
-- New feature ideas. 
+Thank you for your interest in contributing to PatternFly! We depend on community contributions to help our design system grow and evolve. We encourage everyone, regardless of background, to get involved. Common contributions include (but aren't limited to):
+
+- New feature ideas.
 - Bug reports.
 - Documentation updates.
 
@@ -20,29 +22,32 @@ If you have any ideas that don't fit into the projects outlined in this guide, p
 
 If you have skills in visual and interaction design, you can contribute to PatternFly's design by taking an existing issue or proposing a new feature, enhancement, or icon. If you are interested in any of these projects, [reach out on the patternfly-design Slack channel.](http://join.slack.com/t/patternfly/shared_invite/zt-1npmqswgk-bF2R1E2rglV8jz5DNTezMQ)
 
-### Existing design issues 
+### Existing design issues
 
 The PatternFly design team is composed of visual and interaction designers who define the look and feel of the PatternFly library. The team follows an agile framework, planning their work in sprints, with a backlog that is tracked and managed via [this GitHub project board.](https://github.com/orgs/patternfly/projects/7/views/30) This board contains a list issues that are currently unassigned and waiting in the queue. If you see something here that you'd like to work on, leave a comment on the issue and a member of our team will reach out with next steps.
 
 ### New feature or enhancement
+
 If you have an idea for a new design pattern, a new component type, or an existing feature improvement, we'd love to hear it. [Start by opening an issue in the patternfly-design repository.](https://github.com/patternfly/patternfly-design/issues) From there, a member of our team will reach out and work with you to plan and design a solution.
 
 ### New icons
+
 We encourage designers to work with [the existing PatternFly icon set](/design-foundations/icons), which covers most common use cases. If your use case isn't covered, you can propose a new icon.
 
 To contribute a new icon, [start by opening an issue in the patternfly-design repository](https://github.com/patternfly/patternfly-design/issues) that describes your idea and why it's needed. A member of our team will reach out to you to discuss next steps.
 
 ## Code
 
-The primary PatternFly libraries include HTML/CSS (commonly called "core") and React. If you're looking to contribute to PatternFly's codebase, these libraries are a good place to start. You can help out by taking existing issues, or creating issues for bugs and other changes. 
+The primary PatternFly libraries include HTML/CSS (commonly called "core") and React. If you're looking to contribute to PatternFly's codebase, these libraries are a good place to start. You can help out by taking existing issues, or creating issues for bugs and other changes.
 
 If you have any questions about these projects, you can reach out to us on our [patternfly-core](https://patternfly.slack.com/archives/C9Q224EFL) and [patternfly-react](https://patternfly.slack.com/archives/C4FM977N0) Slack channels.
 
-### Existing development issues 
+### Existing development issues
 
-To find work that has been approved, but not started, you can view open issues in our [patternfly](https://github.com/patternfly/patternfly/issues) (HTML/CSS) and [patternfly-react](https://github.com/patternfly/patternfly-react/issues) (React) repositories. If you find an issue that you'd like to work on, leave a comment and someone from our team will reach out to you with next steps. 
+To find work that has been approved, but not started, you can view open issues in our [patternfly](https://github.com/patternfly/patternfly/issues) (HTML/CSS) and [patternfly-react](https://github.com/patternfly/patternfly-react/issues) (React) repositories. If you find an issue that you'd like to work on, leave a comment and someone from our team will reach out to you with next steps.
 
 Be sure to view our detailed contribution instructions for both of these repositories:
+
 - [Core contribution guidelines](https://github.com/patternfly/patternfly#guidelines-for-css-development)
 - [React contribution guidelines](https://github.com/patternfly/patternfly-react/blob/main/CONTRIBUTING.md#contribution-process)
 
@@ -50,13 +55,13 @@ Be sure to view our detailed contribution instructions for both of these reposit
 
 If you believe that you've come across a PatternFly bug, alert our team, so that we can resolve the issue. To report a bug, follow these steps:
 
-1. View the documentation for the feature, to confirm that the behavior is not functioning as intended. 
+1. View the documentation for the feature, to confirm that the behavior is not functioning as intended.
 1. Search open issues in the [patternfly](https://github.com/patternfly/patternfly/issues) and [patternfly-react](https://github.com/patternfly/patternfly-react/issues) repositories to see if a related issue already exists.
-    - If the bug is present in only the React implementation of PatternFly, [create a bug issue in patternfly-react.](https://github.com/patternfly/patternfly-react/issues)
-    - If the bug can be seen on both the React and HTML/CSS side, [create a bug issue in patternfly](https://github.com/patternfly/patternfly/issues).
+   - If the bug is present in only the React implementation of PatternFly, [create a bug issue in patternfly-react.](https://github.com/patternfly/patternfly-react/issues)
+   - If the bug can be seen on both the React and HTML/CSS side, [create a bug issue in patternfly](https://github.com/patternfly/patternfly/issues).
 1. Be sure to mention which project the bug was noticed in and if there is a deadline that the fix is needed for.
 
-## Documentation 
+## Documentation
 
 Across our website, you can find PatternFly documentation that explains concepts, provides guidance, and outlines important resources for PatternFly users. Our documentation can always be improved, and we love to hear input from the people who use it.
 
@@ -64,9 +69,10 @@ If you'd like to contribute to documentation, you can refer to our [detailed con
 
 ### Existing documentation issues
 
-Our website documentation is contained in the [patternfly-org repository](https://github.com/patternfly/patternfly-org). If you find an issue that you'd like to work on, leave a comment and someone from our team will reach out to you with next steps. 
+Our website documentation is contained in the [patternfly-org repository](https://github.com/patternfly/patternfly-org). If you find an issue that you'd like to work on, leave a comment and someone from our team will reach out to you with next steps.
 
 ### Design guidelines
+
 Our design guidelines are found across our component, layout, chart, and pattern web pages. These guides clarify usage details to help designers follow best practices to create strong UI solutions.
 
-If you'd like to contribute to our design guidelines, you can open an issue in [patternfly-org](https://github.com/patternfly/patternfly-org) to propose a new page or updates to an existing page. From there, our team will work with you to author and publish your new content. 
+If you'd like to contribute to our design guidelines, you can open an issue in [patternfly-org](https://github.com/patternfly/patternfly-org) to propose a new page or updates to an existing page. From there, our team will work with you to author and publish your new content.


### PR DESCRIPTION
# To run:

```
npm install
npm run build:props
npm run dev
```

Can test at http://localhost:${yourPortHere}/get-started/contribute

# Questions: 
It seems expand all isn't be used - do we need this? I dropped it.

If types look bizarre, let me know. I am basing it on the data I am seeing, but totally possible it's off. Original wasn't typed. I don't really know what these types need to be.

Do we need any other backend here? I got this hooked up to pull in old docs format.

# Screenshot
<img width="1108" alt="Screenshot 2025-05-08 at 4 58 51 PM" src="https://github.com/user-attachments/assets/2c5f7a11-90d1-448f-b2ed-5227dacd22f3" />
