### PR TITLE
feat(Nav): performance improvements

### DIFF
--- a/src/components/Masthead.astro
+++ b/src/components/Masthead.astro
@@ -16,7 +16,7 @@ import { PageToggle } from './PageToggle'
 <PFMasthead>
   <MastheadMain>
     <MastheadToggle>
-      <PageToggle client:idle />
+      <PageToggle client:idle transition:persist />
     </MastheadToggle>
     <MastheadBrand>
       <MastheadLogo component="a" href="/">

--- a/src/components/NavEntry.tsx
+++ b/src/components/NavEntry.tsx
@@ -6,9 +6,7 @@ export interface TextContentEntry {
   data: {
     id: string
     section: string
-    tab?: string
   }
-  collection: string
 }
 
 interface NavEntryProps {

--- a/src/components/NavSection.tsx
+++ b/src/components/NavSection.tsx
@@ -14,7 +14,7 @@ export const NavSection = ({
   sectionId,
   activeItem,
 }: NavSectionProps) => {
-  const isExpanded = window.location.pathname.includes(sectionId)
+  const isExpanded = window.location.pathname.includes(kebabCase(sectionId))
   const isActive = entries.some((entry) => entry.id === activeItem)
 
   const items = entries.map((entry) => (

--- a/src/components/NavSection.tsx
+++ b/src/components/NavSection.tsx
@@ -15,29 +15,9 @@ export const NavSection = ({
   activeItem,
 }: NavSectionProps) => {
   const isExpanded = window.location.pathname.includes(sectionId)
+  const isActive = entries.some((entry) => entry.id === activeItem)
 
-  const sortedNavEntries = entries.sort((a, b) =>
-    a.data.id.localeCompare(b.data.id),
-  )
-
-  const isActive = sortedNavEntries.some((entry) => entry.id === activeItem)
-
-  let navItems = sortedNavEntries
-  if (sectionId === 'components' || sectionId === 'layouts') {
-    // only display unique entry.data.id in the nav list if the section is components
-    navItems = [
-      ...sortedNavEntries
-        .reduce((map, entry) => {
-          if (!map.has(entry.data.id)) {
-            map.set(entry.data.id, entry)
-          }
-          return map
-        }, new Map())
-        .values(),
-    ]
-  }
-
-  const items = navItems.map((entry) => (
+  const items = entries.map((entry) => (
     <NavEntry
       key={entry.id}
       entry={entry}

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -2,6 +2,7 @@
 import { getCollection } from 'astro:content'
 
 import { Navigation as ReactNav } from './Navigation.tsx'
+import { TextContentEntry } from './NavEntry.tsx'
 
 import { content } from '../content'
 
@@ -13,12 +14,18 @@ const collections = await Promise.all(
   ),
 )
 
-const navEntries = collections.flat()
+const navEntries = collections.flat();
+const sections = new Set(navEntries.map((entry) => entry.data.section));
+
+const navSectionData: Record<string, TextContentEntry[]> = {};
+Array.from(sections).map((section) => {
+  const entries = navEntries.filter((entry) => entry.data.section === section).map(entry => ({id: entry.id, data: {id: entry.data.id, section }} as TextContentEntry))
+
+  navSectionData[section] = entries;
+})
+
 ---
 
-<ReactNav
-  client:only="react"
-  navEntries={navEntries}
-  navSectionOrder={config.navSectionOrder}
-  transition:animate="fade"
+<ReactNav client:only="react" navData={navSectionData} navSectionOrder={config.navSectionOrder}
+transition:animate="fade"
 />

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -14,18 +14,56 @@ const collections = await Promise.all(
   ),
 )
 
-const navEntries = collections.flat();
-const sections = new Set(navEntries.map((entry) => entry.data.section));
+const navDataRaw = collections.flat();
+const uniqueSections = new Set(navDataRaw.map((entry) => entry.data.section));
+const navData: Record<string, TextContentEntry[]> = {};
 
-const navSectionData: Record<string, TextContentEntry[]> = {};
-Array.from(sections).map((section) => {
-  const entries = navEntries.filter((entry) => entry.data.section === section).map(entry => ({id: entry.id, data: {id: entry.data.id, section }} as TextContentEntry))
+const [orderedSections, unorderedSections] = Array.from(uniqueSections).reduce(
+    (acc, section) => {
+      if (!config.navSectionOrder) {
+        acc[1].push(section)
+        return acc
+      }
 
-  navSectionData[section] = entries;
+      const index = config.navSectionOrder.indexOf(section)
+      if (index > -1) {
+        acc[0][index] = section
+      } else {
+        acc[1].push(section)
+      }
+      return acc
+    },
+    [[], []] as [string[], string[]],
+  )
+
+const sortedSections = [...orderedSections, ...unorderedSections.sort()]
+sortedSections.map((section) => {
+  const entries = navDataRaw
+    .filter((entry) => entry.data.section === section)
+    .map(entry => ({ id: entry.id, data: { id: entry.data.id, section }} as TextContentEntry))
+
+  const sortedEntries = entries.sort((a, b) =>
+    a.data.id.localeCompare(b.data.id),
+  )
+
+  let navEntries = sortedEntries
+  if (section === 'components' || section === 'layouts') {
+    // only display unique entry.data.id in the nav list if the section is components
+    navEntries = [
+      ...sortedEntries
+        .reduce((map, entry) => {
+          if (!map.has(entry.data.id)) {
+            map.set(entry.data.id, entry)
+          }
+          return map
+        }, new Map())
+        .values(),
+    ]
+  }
+
+  navData[section] = navEntries;
 })
 
 ---
 
-<ReactNav client:only="react" navData={navSectionData} navSectionOrder={config.navSectionOrder}
-transition:animate="fade"
-/>
+<ReactNav client:only="react" navData={navData} transition:animate="fade" />

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,19 +4,21 @@ import { NavSection } from './NavSection'
 import { type TextContentEntry } from './NavEntry'
 
 interface NavigationProps {
-  navEntries: TextContentEntry[]
+  navEntries?: TextContentEntry[]
+  navData: Record<string, TextContentEntry[]>
   navSectionOrder?: string[]
 }
 
 export const Navigation: React.FunctionComponent<NavigationProps> = ({
   navEntries,
+  navData,
   navSectionOrder,
 }: NavigationProps) => {
   const [activeItem, setActiveItem] = useState('')
 
   useEffect(() => {
     // TODO: Needs an alternate solution because of /tab in the path
-    setActiveItem(window.location.pathname.split('/').reverse()[0]) 
+    setActiveItem(window.location.pathname.split('/').reverse()[0])
   }, [])
 
   const onNavSelect = (
@@ -26,48 +28,58 @@ export const Navigation: React.FunctionComponent<NavigationProps> = ({
     setActiveItem(selectedItem.itemId.toString())
   }
 
-  const uniqueSections = Array.from(
-    new Set(navEntries.map((entry) => entry.data.section)),
-  )
+  // const uniqueSections = Array.from(
+  //   new Set(navEntries.map((entry) => entry.data.section)),
+  // )
 
   // We want to list any ordered sections first, followed by any unordered sections sorted alphabetically
-  const [orderedSections, unorderedSections] = uniqueSections.reduce(
-    (acc, section) => {
-      if (!navSectionOrder) {
-        acc[1].push(section)
-        return acc
-      }
+  // TODO update with new navData logic
+  // const [orderedSections, unorderedSections] = Object.entries(navData).reduce(
+  //   (acc, section) => {
+  //     if (!navSectionOrder) {
+  //       acc[1].push(section)
+  //       return acc
+  //     }
 
-      const index = navSectionOrder.indexOf(section)
-      if (index > -1) {
-        acc[0][index] = section
-      } else {
-        acc[1].push(section)
-      }
-      return acc
-    },
-    [[], []] as [string[], string[]],
-  )
-  const sortedSections = [...orderedSections, ...unorderedSections.sort()]
+  //     const index = navSectionOrder.indexOf(section)
+  //     if (index > -1) {
+  //       acc[0][index] = section
+  //     } else {
+  //       acc[1].push(section)
+  //     }
+  //     return acc
+  //   },
+  //   [[], []] as [string[], string[]],
+  // )
+  // const sortedSections = [...orderedSections, ...unorderedSections.sort()]
 
-  const navSections = sortedSections.map((section) => {
-    const entries = navEntries.filter((entry) => entry.data.section === section)
+  // const navSections = sortedSections.map((section) => {
+  //   const entries = navEntries.filter((entry) => entry.data.section === section)
 
-    return (
-      <NavSection
-        key={section}
-        entries={entries}
-        sectionId={section}
-        activeItem={activeItem}
-      />
-    )
-  })
+  //   return (
+  //     <NavSection
+  //       key={section}
+  //       entries={entries}
+  //       sectionId={section}
+  //       activeItem={activeItem}
+  //     />
+  //   )
+  // })
 
   return (
     // Can possibly add back PageSidebar wrapper when https://github.com/patternfly/patternfly/issues/7377 goes in
     <PageSidebarBody id="page-sidebar-body">
       <Nav onSelect={onNavSelect}>
-        <NavList>{navSections}</NavList>
+        <NavList>
+          {Object.entries(navData).map(([key, value], index) => (
+            <NavSection
+              key={index}
+              entries={value}
+              sectionId={key}
+              activeItem={activeItem}
+            />
+          ))}
+        </NavList>
       </Nav>
     </PageSidebarBody>
   )

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,15 +4,11 @@ import { NavSection } from './NavSection'
 import { type TextContentEntry } from './NavEntry'
 
 interface NavigationProps {
-  navEntries?: TextContentEntry[]
   navData: Record<string, TextContentEntry[]>
-  navSectionOrder?: string[]
 }
 
 export const Navigation: React.FunctionComponent<NavigationProps> = ({
-  navEntries,
   navData,
-  navSectionOrder,
 }: NavigationProps) => {
   const [activeItem, setActiveItem] = useState('')
 
@@ -27,44 +23,6 @@ export const Navigation: React.FunctionComponent<NavigationProps> = ({
   ) => {
     setActiveItem(selectedItem.itemId.toString())
   }
-
-  // const uniqueSections = Array.from(
-  //   new Set(navEntries.map((entry) => entry.data.section)),
-  // )
-
-  // We want to list any ordered sections first, followed by any unordered sections sorted alphabetically
-  // TODO update with new navData logic
-  // const [orderedSections, unorderedSections] = Object.entries(navData).reduce(
-  //   (acc, section) => {
-  //     if (!navSectionOrder) {
-  //       acc[1].push(section)
-  //       return acc
-  //     }
-
-  //     const index = navSectionOrder.indexOf(section)
-  //     if (index > -1) {
-  //       acc[0][index] = section
-  //     } else {
-  //       acc[1].push(section)
-  //     }
-  //     return acc
-  //   },
-  //   [[], []] as [string[], string[]],
-  // )
-  // const sortedSections = [...orderedSections, ...unorderedSections.sort()]
-
-  // const navSections = sortedSections.map((section) => {
-  //   const entries = navEntries.filter((entry) => entry.data.section === section)
-
-  //   return (
-  //     <NavSection
-  //       key={section}
-  //       entries={entries}
-  //       sectionId={section}
-  //       activeItem={activeItem}
-  //     />
-  //   )
-  // })
 
   return (
     // Can possibly add back PageSidebar wrapper when https://github.com/patternfly/patternfly/issues/7377 goes in

--- a/src/components/__tests__/NavEntry.test.tsx
+++ b/src/components/__tests__/NavEntry.test.tsx
@@ -1,36 +1,36 @@
-
-import { render, screen } from '@testing-library/react';
-import { NavEntry, TextContentEntry } from '../NavEntry';
+import { render, screen } from '@testing-library/react'
+import { NavEntry, TextContentEntry } from '../NavEntry'
 
 const mockEntry: TextContentEntry = {
   id: 'entry1',
   data: { id: 'Entry1', section: 'section1' },
-  collection: 'textContent',
-};
+}
 
 describe('NavEntry', () => {
   it('renders without crashing', () => {
-    render(<NavEntry entry={mockEntry} isActive={false} />);
-    expect(screen.getByText('Entry1')).toBeInTheDocument();
-  });
+    render(<NavEntry entry={mockEntry} isActive={false} />)
+    expect(screen.getByText('Entry1')).toBeInTheDocument()
+  })
 
   it('renders the correct link', () => {
-    render(<NavEntry entry={mockEntry} isActive={false} />);
-    expect(screen.getByRole('link')).toHaveAttribute('href', '/section1/entry1');
-  });
+    render(<NavEntry entry={mockEntry} isActive={false} />)
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/section1/entry1')
+  })
 
   it('marks the entry as active if isActive is true', () => {
-    render(<NavEntry entry={mockEntry} isActive={true} />);
-    expect(screen.getByRole('link')).toHaveClass('pf-m-current');
-  });
+    render(<NavEntry entry={mockEntry} isActive={true} />)
+    expect(screen.getByRole('link')).toHaveClass('pf-m-current')
+  })
 
   it('does not mark the entry as active if isActive is false', () => {
-    render(<NavEntry entry={mockEntry} isActive={false} />);
-    expect(screen.getByRole('link')).not.toHaveClass('pf-m-current');
-  });
+    render(<NavEntry entry={mockEntry} isActive={false} />)
+    expect(screen.getByRole('link')).not.toHaveClass('pf-m-current')
+  })
 
   it('matches snapshot', () => {
-    const { asFragment } = render(<NavEntry entry={mockEntry} isActive={false} />);
-    expect(asFragment()).toMatchSnapshot();
-  });
-});
+    const { asFragment } = render(
+      <NavEntry entry={mockEntry} isActive={false} />,
+    )
+    expect(asFragment()).toMatchSnapshot()
+  })
+})

--- a/src/components/__tests__/NavSection.test.tsx
+++ b/src/components/__tests__/NavSection.test.tsx
@@ -6,35 +6,14 @@ const mockEntries: TextContentEntry[] = [
   {
     id: 'entry1',
     data: { id: 'Entry1', section: 'section1' },
-    collection: 'textContent',
   },
   {
     id: 'entry2',
     data: { id: 'Entry2', section: 'Section1' },
-    collection: 'textContent',
   },
   {
     id: 'entry3',
     data: { id: 'Entry3', section: 'Section1' },
-    collection: 'textContent',
-  },
-]
-
-const dupedEntries: TextContentEntry[] = [
-  {
-    id: 'entry1',
-    data: { id: 'Entry1', section: 'components' },
-    collection: 'react',
-  },
-  {
-    id: 'entry2',
-    data: { id: 'Entry1', section: 'components' },
-    collection: 'react',
-  },
-  {
-    id: 'entry3',
-    data: { id: 'Entry2', section: 'components' },
-    collection: 'react',
   },
 ]
 
@@ -158,46 +137,4 @@ it('matches snapshot', () => {
     />,
   )
   expect(asFragment()).toMatchSnapshot()
-})
-
-it('dedupes and renders correct number of entries for components section', () => {
-  Object.defineProperty(window, 'location', {
-    value: {
-      pathname: '/foo/components',
-    },
-    writable: true,
-  })
-
-  render(
-    <NavSection
-      entries={dupedEntries}
-      sectionId="components"
-      activeItem="entry1"
-    />,
-  )
-
-  expect(screen.getAllByRole('listitem')).toHaveLength(3)
-  expect(screen.getByRole('link', { name: 'Entry1' })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: 'Entry2' })).toBeInTheDocument()
-})
-
-it('dedupes and renders correct number of entries for layouts section', () => {
-  Object.defineProperty(window, 'location', {
-    value: {
-      pathname: '/foo/layouts',
-    },
-    writable: true,
-  })
-
-  render(
-    <NavSection
-      entries={dupedEntries}
-      sectionId="layouts"
-      activeItem="entry1"
-    />,
-  )
-
-  expect(screen.getAllByRole('listitem')).toHaveLength(3)
-  expect(screen.getByRole('link', { name: 'Entry1' })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: 'Entry2' })).toBeInTheDocument()
 })

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -3,42 +3,39 @@ import userEvent from '@testing-library/user-event'
 import { Navigation } from '../Navigation'
 import { TextContentEntry } from '../NavEntry'
 
-const mockEntries: TextContentEntry[] = [
-  {
-    id: 'entry1',
-    data: { id: 'Entry1', section: 'section-one' },
-    collection: 'textContent',
-  },
-  {
-    id: 'entry2',
-    data: { id: 'Entry2', section: 'section-two' },
-    collection: 'textContent',
-  },
-  {
-    id: 'entry3',
-    data: { id: 'Entry3', section: 'section-two' },
-    collection: 'textContent',
-  },
-  {
-    id: 'entry4',
-    data: { id: 'Entry4', section: 'section-three' },
-    collection: 'textContent',
-  },
-  {
-    id: 'entry5',
-    data: { id: 'Entry5', section: 'section-four' },
-    collection: 'textContent',
-  },
-]
+const mockEntries: Record<string, TextContentEntry[]> = {
+  section1: [
+    {
+      id: 'entry1',
+      data: { id: 'Entry1', section: 'section-one' },
+    },
+    {
+      id: 'entry2',
+      data: { id: 'Entry2', section: 'section-two' },
+    },
+    {
+      id: 'entry3',
+      data: { id: 'Entry3', section: 'section-two' },
+    },
+    {
+      id: 'entry4',
+      data: { id: 'Entry4', section: 'section-three' },
+    },
+    {
+      id: 'entry5',
+      data: { id: 'Entry5', section: 'section-four' },
+    },
+  ],
+}
 
 it('renders without crashing', () => {
-  render(<Navigation navEntries={mockEntries} />)
+  render(<Navigation navData={mockEntries} />)
   expect(screen.getByText('Section one')).toBeInTheDocument()
   expect(screen.getByText('Section two')).toBeInTheDocument()
 })
 
 it('renders the correct number of sections', () => {
-  render(<Navigation navEntries={mockEntries} />)
+  render(<Navigation navData={mockEntries} />)
   expect(screen.getAllByRole('listitem')).toHaveLength(4)
 })
 
@@ -50,7 +47,7 @@ it('sets the active item based on the current pathname', () => {
     writable: true,
   })
 
-  render(<Navigation navEntries={mockEntries} />)
+  render(<Navigation navData={mockEntries} />)
 
   const entryLink = screen.getByRole('link', { name: 'Entry1' })
 
@@ -63,7 +60,7 @@ it('updates the active item on selection', async () => {
 
   const user = userEvent.setup()
 
-  render(<Navigation navEntries={mockEntries} />)
+  render(<Navigation navData={mockEntries} />)
 
   const sectionTwo = screen.getByRole('button', { name: 'Section two' })
 
@@ -76,43 +73,7 @@ it('updates the active item on selection', async () => {
   expect(entryLink).toHaveClass('pf-m-current')
 })
 
-it('sorts all sections alphabetically by default', () => {
-  render(<Navigation navEntries={mockEntries} />)
-
-  const sections = screen.getAllByRole('button')
-
-  expect(sections[0]).toHaveTextContent('Section four')
-  expect(sections[1]).toHaveTextContent('Section one')
-  expect(sections[2]).toHaveTextContent('Section three')
-  expect(sections[3]).toHaveTextContent('Section two')
-})
-
-it('sorts sections based on the order provided', () => {
-  render(
-    <Navigation
-      navEntries={mockEntries}
-      navSectionOrder={['section-two', 'section-one']}
-    />,
-  )
-
-  const sections = screen.getAllByRole('button')
-
-  expect(sections[0]).toHaveTextContent('Section two')
-  expect(sections[1]).toHaveTextContent('Section one')
-})
-
-it('sorts unordered sections alphabetically after ordered sections', () => {
-  render(
-    <Navigation navEntries={mockEntries} navSectionOrder={['section-two']} />,
-  )
-
-  const sections = screen.getAllByRole('button')
-
-  expect(sections[2]).toHaveTextContent('Section one')
-  expect(sections[3]).toHaveTextContent('Section three')
-})
-
 it('matches snapshot', () => {
-  const { asFragment } = render(<Navigation navEntries={mockEntries} />)
+  const { asFragment } = render(<Navigation navData={mockEntries} />)
   expect(asFragment()).toMatchSnapshot()
 })

--- a/src/components/__tests__/Navigation.test.tsx
+++ b/src/components/__tests__/Navigation.test.tsx
@@ -4,26 +4,40 @@ import { Navigation } from '../Navigation'
 import { TextContentEntry } from '../NavEntry'
 
 const mockEntries: Record<string, TextContentEntry[]> = {
-  section1: [
+  'section one': [
     {
       id: 'entry1',
       data: { id: 'Entry1', section: 'section-one' },
     },
     {
       id: 'entry2',
-      data: { id: 'Entry2', section: 'section-two' },
+      data: { id: 'Entry2', section: 'section-one' },
     },
     {
       id: 'entry3',
-      data: { id: 'Entry3', section: 'section-two' },
+      data: { id: 'Entry3', section: 'section-one' },
     },
     {
       id: 'entry4',
-      data: { id: 'Entry4', section: 'section-three' },
+      data: { id: 'Entry4', section: 'section-one' },
     },
     {
       id: 'entry5',
-      data: { id: 'Entry5', section: 'section-four' },
+      data: { id: 'Entry5', section: 'section-one' },
+    },
+  ],
+  'section two': [
+    {
+      id: 'entry6',
+      data: { id: 'Entry6', section: 'section-two' },
+    },
+    {
+      id: 'entry7',
+      data: { id: 'Entry7', section: 'section-two' },
+    },
+    {
+      id: 'entry8',
+      data: { id: 'Entry8', section: 'section-two' },
     },
   ],
 }
@@ -36,7 +50,7 @@ it('renders without crashing', () => {
 
 it('renders the correct number of sections', () => {
   render(<Navigation navData={mockEntries} />)
-  expect(screen.getAllByRole('listitem')).toHaveLength(4)
+  expect(screen.getAllByRole('listitem')).toHaveLength(2)
 })
 
 it('sets the active item based on the current pathname', () => {
@@ -66,7 +80,7 @@ it('updates the active item on selection', async () => {
 
   await user.click(sectionTwo)
 
-  const entryLink = screen.getByRole('link', { name: 'Entry2' })
+  const entryLink = screen.getByRole('link', { name: 'Entry6' })
 
   await user.click(entryLink)
 

--- a/src/components/__tests__/__snapshots__/Navigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Navigation.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`matches snapshot 1`] = `
     <nav
       aria-label="Global"
       class="pf-v6-c-nav"
-      data-ouia-component-id="OUIA-Generated-Nav-6"
+      data-ouia-component-id="OUIA-Generated-Nav-4"
       data-ouia-component-type="PF6/Nav"
       data-ouia-safe="true"
     >
@@ -18,17 +18,17 @@ exports[`matches snapshot 1`] = `
         role="list"
       >
         <li
-          class="pf-v6-c-nav__item"
-          data-ouia-component-id="OUIA-Generated-NavExpandable-21"
+          class="pf-v6-c-nav__item pf-m-current"
+          data-ouia-component-id="OUIA-Generated-NavExpandable-4"
           data-ouia-component-type="PF6/NavExpandable"
           data-ouia-safe="true"
         >
           <button
             aria-expanded="false"
             class="pf-v6-c-nav__link"
-            id="nav-section-section-four"
+            id="nav-section-section1"
           >
-            Section four
+            Section1
             <span
               class="pf-v6-c-nav__toggle"
             >
@@ -52,7 +52,7 @@ exports[`matches snapshot 1`] = `
             </span>
           </button>
           <section
-            aria-labelledby="nav-section-section-four"
+            aria-labelledby="nav-section-section1"
             class="pf-v6-c-nav__subnav"
             hidden=""
           >
@@ -62,70 +62,7 @@ exports[`matches snapshot 1`] = `
             >
               <li
                 class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-26"
-                data-ouia-component-type="PF6/NavItem"
-                data-ouia-safe="true"
-              >
-                <a
-                  class="pf-v6-c-nav__link"
-                  href="/section-four/entry5"
-                  id="nav-entry-entry5"
-                >
-                  <span
-                    class="pf-v6-c-nav__link-text"
-                  >
-                    Entry5
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </section>
-        </li>
-        <li
-          class="pf-v6-c-nav__item pf-m-expanded pf-m-current"
-          data-ouia-component-id="OUIA-Generated-NavExpandable-22"
-          data-ouia-component-type="PF6/NavExpandable"
-          data-ouia-safe="true"
-        >
-          <button
-            aria-expanded="true"
-            class="pf-v6-c-nav__link"
-            id="nav-section-section-one"
-          >
-            Section one
-            <span
-              class="pf-v6-c-nav__toggle"
-            >
-              <span
-                class="pf-v6-c-nav__toggle-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </button>
-          <section
-            aria-labelledby="nav-section-section-one"
-            class="pf-v6-c-nav__subnav"
-          >
-            <ul
-              class="pf-v6-c-nav__list"
-              role="list"
-            >
-              <li
-                class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-27"
+                data-ouia-component-id="OUIA-Generated-NavItem-16"
                 data-ouia-component-type="PF6/NavItem"
                 data-ouia-safe="true"
               >
@@ -142,119 +79,9 @@ exports[`matches snapshot 1`] = `
                   </span>
                 </a>
               </li>
-            </ul>
-          </section>
-        </li>
-        <li
-          class="pf-v6-c-nav__item"
-          data-ouia-component-id="OUIA-Generated-NavExpandable-23"
-          data-ouia-component-type="PF6/NavExpandable"
-          data-ouia-safe="true"
-        >
-          <button
-            aria-expanded="false"
-            class="pf-v6-c-nav__link"
-            id="nav-section-section-three"
-          >
-            Section three
-            <span
-              class="pf-v6-c-nav__toggle"
-            >
-              <span
-                class="pf-v6-c-nav__toggle-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </button>
-          <section
-            aria-labelledby="nav-section-section-three"
-            class="pf-v6-c-nav__subnav"
-            hidden=""
-          >
-            <ul
-              class="pf-v6-c-nav__list"
-              role="list"
-            >
               <li
                 class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-28"
-                data-ouia-component-type="PF6/NavItem"
-                data-ouia-safe="true"
-              >
-                <a
-                  class="pf-v6-c-nav__link"
-                  href="/section-three/entry4"
-                  id="nav-entry-entry4"
-                >
-                  <span
-                    class="pf-v6-c-nav__link-text"
-                  >
-                    Entry4
-                  </span>
-                </a>
-              </li>
-            </ul>
-          </section>
-        </li>
-        <li
-          class="pf-v6-c-nav__item"
-          data-ouia-component-id="OUIA-Generated-NavExpandable-24"
-          data-ouia-component-type="PF6/NavExpandable"
-          data-ouia-safe="true"
-        >
-          <button
-            aria-expanded="false"
-            class="pf-v6-c-nav__link"
-            id="nav-section-section-two"
-          >
-            Section two
-            <span
-              class="pf-v6-c-nav__toggle"
-            >
-              <span
-                class="pf-v6-c-nav__toggle-icon"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="pf-v6-svg"
-                  fill="currentColor"
-                  height="1em"
-                  role="img"
-                  viewBox="0 0 256 512"
-                  width="1em"
-                >
-                  <path
-                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
-                  />
-                </svg>
-              </span>
-            </span>
-          </button>
-          <section
-            aria-labelledby="nav-section-section-two"
-            class="pf-v6-c-nav__subnav"
-            hidden=""
-          >
-            <ul
-              class="pf-v6-c-nav__list"
-              role="list"
-            >
-              <li
-                class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-29"
+                data-ouia-component-id="OUIA-Generated-NavItem-17"
                 data-ouia-component-type="PF6/NavItem"
                 data-ouia-safe="true"
               >
@@ -272,7 +99,7 @@ exports[`matches snapshot 1`] = `
               </li>
               <li
                 class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-30"
+                data-ouia-component-id="OUIA-Generated-NavItem-18"
                 data-ouia-component-type="PF6/NavItem"
                 data-ouia-safe="true"
               >
@@ -285,6 +112,42 @@ exports[`matches snapshot 1`] = `
                     class="pf-v6-c-nav__link-text"
                   >
                     Entry3
+                  </span>
+                </a>
+              </li>
+              <li
+                class="pf-v6-c-nav__item"
+                data-ouia-component-id="OUIA-Generated-NavItem-19"
+                data-ouia-component-type="PF6/NavItem"
+                data-ouia-safe="true"
+              >
+                <a
+                  class="pf-v6-c-nav__link"
+                  href="/section-three/entry4"
+                  id="nav-entry-entry4"
+                >
+                  <span
+                    class="pf-v6-c-nav__link-text"
+                  >
+                    Entry4
+                  </span>
+                </a>
+              </li>
+              <li
+                class="pf-v6-c-nav__item"
+                data-ouia-component-id="OUIA-Generated-NavItem-20"
+                data-ouia-component-type="PF6/NavItem"
+                data-ouia-safe="true"
+              >
+                <a
+                  class="pf-v6-c-nav__link"
+                  href="/section-four/entry5"
+                  id="nav-entry-entry5"
+                >
+                  <span
+                    class="pf-v6-c-nav__link-text"
+                  >
+                    Entry5
                   </span>
                 </a>
               </li>

--- a/src/components/__tests__/__snapshots__/Navigation.test.tsx.snap
+++ b/src/components/__tests__/__snapshots__/Navigation.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`matches snapshot 1`] = `
     <nav
       aria-label="Global"
       class="pf-v6-c-nav"
-      data-ouia-component-id="OUIA-Generated-Nav-4"
+      data-ouia-component-id="OUIA-Generated-Nav-3"
       data-ouia-component-type="PF6/Nav"
       data-ouia-safe="true"
     >
@@ -18,17 +18,17 @@ exports[`matches snapshot 1`] = `
         role="list"
       >
         <li
-          class="pf-v6-c-nav__item pf-m-current"
-          data-ouia-component-id="OUIA-Generated-NavExpandable-4"
+          class="pf-v6-c-nav__item pf-m-expanded pf-m-current"
+          data-ouia-component-id="OUIA-Generated-NavExpandable-5"
           data-ouia-component-type="PF6/NavExpandable"
           data-ouia-safe="true"
         >
           <button
-            aria-expanded="false"
+            aria-expanded="true"
             class="pf-v6-c-nav__link"
-            id="nav-section-section1"
+            id="nav-section-section one"
           >
-            Section1
+            Section one
             <span
               class="pf-v6-c-nav__toggle"
             >
@@ -52,9 +52,8 @@ exports[`matches snapshot 1`] = `
             </span>
           </button>
           <section
-            aria-labelledby="nav-section-section1"
+            aria-labelledby="nav-section-section one"
             class="pf-v6-c-nav__subnav"
-            hidden=""
           >
             <ul
               class="pf-v6-c-nav__list"
@@ -62,7 +61,7 @@ exports[`matches snapshot 1`] = `
             >
               <li
                 class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-16"
+                data-ouia-component-id="OUIA-Generated-NavItem-17"
                 data-ouia-component-type="PF6/NavItem"
                 data-ouia-safe="true"
               >
@@ -81,13 +80,13 @@ exports[`matches snapshot 1`] = `
               </li>
               <li
                 class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-17"
+                data-ouia-component-id="OUIA-Generated-NavItem-18"
                 data-ouia-component-type="PF6/NavItem"
                 data-ouia-safe="true"
               >
                 <a
                   class="pf-v6-c-nav__link"
-                  href="/section-two/entry2"
+                  href="/section-one/entry2"
                   id="nav-entry-entry2"
                 >
                   <span
@@ -99,13 +98,13 @@ exports[`matches snapshot 1`] = `
               </li>
               <li
                 class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-18"
+                data-ouia-component-id="OUIA-Generated-NavItem-19"
                 data-ouia-component-type="PF6/NavItem"
                 data-ouia-safe="true"
               >
                 <a
                   class="pf-v6-c-nav__link"
-                  href="/section-two/entry3"
+                  href="/section-one/entry3"
                   id="nav-entry-entry3"
                 >
                   <span
@@ -117,13 +116,13 @@ exports[`matches snapshot 1`] = `
               </li>
               <li
                 class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-19"
+                data-ouia-component-id="OUIA-Generated-NavItem-20"
                 data-ouia-component-type="PF6/NavItem"
                 data-ouia-safe="true"
               >
                 <a
                   class="pf-v6-c-nav__link"
-                  href="/section-three/entry4"
+                  href="/section-one/entry4"
                   id="nav-entry-entry4"
                 >
                   <span
@@ -135,19 +134,119 @@ exports[`matches snapshot 1`] = `
               </li>
               <li
                 class="pf-v6-c-nav__item"
-                data-ouia-component-id="OUIA-Generated-NavItem-20"
+                data-ouia-component-id="OUIA-Generated-NavItem-21"
                 data-ouia-component-type="PF6/NavItem"
                 data-ouia-safe="true"
               >
                 <a
                   class="pf-v6-c-nav__link"
-                  href="/section-four/entry5"
+                  href="/section-one/entry5"
                   id="nav-entry-entry5"
                 >
                   <span
                     class="pf-v6-c-nav__link-text"
                   >
                     Entry5
+                  </span>
+                </a>
+              </li>
+            </ul>
+          </section>
+        </li>
+        <li
+          class="pf-v6-c-nav__item"
+          data-ouia-component-id="OUIA-Generated-NavExpandable-6"
+          data-ouia-component-type="PF6/NavExpandable"
+          data-ouia-safe="true"
+        >
+          <button
+            aria-expanded="false"
+            class="pf-v6-c-nav__link"
+            id="nav-section-section two"
+          >
+            Section two
+            <span
+              class="pf-v6-c-nav__toggle"
+            >
+              <span
+                class="pf-v6-c-nav__toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </span>
+            </span>
+          </button>
+          <section
+            aria-labelledby="nav-section-section two"
+            class="pf-v6-c-nav__subnav"
+            hidden=""
+          >
+            <ul
+              class="pf-v6-c-nav__list"
+              role="list"
+            >
+              <li
+                class="pf-v6-c-nav__item"
+                data-ouia-component-id="OUIA-Generated-NavItem-22"
+                data-ouia-component-type="PF6/NavItem"
+                data-ouia-safe="true"
+              >
+                <a
+                  class="pf-v6-c-nav__link"
+                  href="/section-two/entry6"
+                  id="nav-entry-entry6"
+                >
+                  <span
+                    class="pf-v6-c-nav__link-text"
+                  >
+                    Entry6
+                  </span>
+                </a>
+              </li>
+              <li
+                class="pf-v6-c-nav__item"
+                data-ouia-component-id="OUIA-Generated-NavItem-23"
+                data-ouia-component-type="PF6/NavItem"
+                data-ouia-safe="true"
+              >
+                <a
+                  class="pf-v6-c-nav__link"
+                  href="/section-two/entry7"
+                  id="nav-entry-entry7"
+                >
+                  <span
+                    class="pf-v6-c-nav__link-text"
+                  >
+                    Entry7
+                  </span>
+                </a>
+              </li>
+              <li
+                class="pf-v6-c-nav__item"
+                data-ouia-component-id="OUIA-Generated-NavItem-24"
+                data-ouia-component-type="PF6/NavItem"
+                data-ouia-safe="true"
+              >
+                <a
+                  class="pf-v6-c-nav__link"
+                  href="/section-two/entry8"
+                  id="nav-entry-entry8"
+                >
+                  <span
+                    class="pf-v6-c-nav__link-text"
+                  >
+                    Entry8
                   </span>
                 </a>
               </li>


### PR DESCRIPTION
- Moves raw entry data manipulation out of the Navigation components (creating nav entry data, sorting & deduping sections & entries)
- Removes some tests for now as the above isn't inside the Nav anymore. I may look at refactoring some of the logic of the deduping / sorting into a util file which we can test, or see if we can test the code fenced block somehow.

Open question/thoughts:
I think we can probably clean up the data structure that Navigation gets a bit more, the TextContentEntry probably doesn't need the `data.section` now because that info is in the Record, and it doesn't have to match the entry data structure (so we can probably move away from `id, data: {id}` style).
