### PR TITLE
fix(cli): avoid removing relative imports during md -> mdx conversion

### DIFF
--- a/cli/convertToMDX.ts
+++ b/cli/convertToMDX.ts
@@ -46,8 +46,8 @@ function removeNoLiveTags(content: string): string {
 }
 
 function removeExistingImports(content: string): string {
-  // Remove imports that don't end in .css
-  const importRegex = /^import {?[\w\s,\n]*}? from ['"](?!.*\.css['"])[^'"]*['"];?\n/gm
+  // Remove imports that are absolute and not CSS
+  const importRegex = /^import {?[\w\s,\n]*}? from ['"](?!\.\.?\/)(?!.*\.css['"])[^'"]*['"];?\n/gm
   return content.replace(importRegex, '')
 }
 


### PR DESCRIPTION
Closes #188

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved import removal logic during MDX conversion to correctly handle absolute imports that aren't CSS files, enhancing the content transformation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->