### PR TITLE
feat(API): Add API only build mode

### DIFF
--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -113,7 +113,11 @@ async function initializeApiIndex(program: Command) {
 }
 
 async function buildProject(program: Command): Promise<DocsConfig | undefined> {
-  const { verbose } = program.opts()
+  const { verbose, apiOnly } = program.opts()
+
+  if (apiOnly) {
+    process.env.PF_API_ONLY = 'true'
+  }
 
   if (!config) {
     console.error(
@@ -191,6 +195,7 @@ program.name('pf-doc-core')
 program.option('--verbose', 'verbose mode', false)
 program.option('--props', 'generate props data', false)
 program.option('--dry-run', 'dry run mode', false)
+program.option('--api-only', 'only build API and component pages, skip standalone content pages', false)
 
 program.command('setup').action(async () => {
   await Promise.all([
@@ -212,6 +217,10 @@ program.command('init').action(async () => {
 })
 
 program.command('start').action(async () => {
+  const { apiOnly } = program.opts()
+  if (apiOnly) {
+    process.env.PF_API_ONLY = 'true'
+  }
   await updateContent(program)
   await initializeApiIndex(program)
 

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,26 +1,22 @@
 ---
-import MainLayout from '../layouts/Main.astro'
-
 const apiOnly = process.env.PF_API_ONLY === 'true'
 ---
 
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width" />
-    <meta name="generator" content={Astro.generator} />
-    <title>PatternFly</title>
+    <title>404 - Not Found</title>
   </head>
   <body>
     {apiOnly ? (
       <>
-        <h1>PatternFly API</h1>
+        <h1>404 - Not Found</h1>
         <p>This build only serves API routes. Content pages are not available.</p>
         <p>Available endpoints are under <a href="/api">/api</a>.</p>
       </>
     ) : (
-      <MainLayout title="PatternFly X Astro"> Page content </MainLayout>
+      <h1>404 - Page not found</h1>
     )}
   </body>
 </html>

--- a/src/pages/[section]/[...page].astro
+++ b/src/pages/[section]/[...page].astro
@@ -30,17 +30,17 @@ import {
 import DocsTables from '../../components/DocsTables.astro'
 
 export async function getStaticPaths() {
-  const collections = await Promise.all(
-    content.map(
-      async (entry) => await getCollection(entry.name as 'textContent'),
-    ),
-  )
-
   const apiOnly = process.env.PF_API_ONLY === 'true'
 
   if (apiOnly) {
     return []
   }
+  
+  const collections = await Promise.all(
+    content.map(
+      async (entry) => await getCollection(entry.name as 'textContent'),
+    ),
+  )
 
   return collections.flat().map((entry) => {
     const { filePath } = entry

--- a/src/pages/[section]/[...page].astro
+++ b/src/pages/[section]/[...page].astro
@@ -36,6 +36,12 @@ export async function getStaticPaths() {
     ),
   )
 
+  const apiOnly = process.env.PF_API_ONLY === 'true'
+
+  if (apiOnly) {
+    return []
+  }
+
   return collections.flat().map((entry) => {
     const { filePath } = entry
     const { tab, source, tabName } = entry.data

--- a/src/pages/[section]/[page]/[tab].astro
+++ b/src/pages/[section]/[page]/[tab].astro
@@ -31,17 +31,17 @@ import DocsTables from '../../../components/DocsTables.astro'
 import { addDemosOrDeprecated, getDefaultTab } from '../../../utils'
 
 export async function getStaticPaths() {
-  const collections = await Promise.all(
-    content.map(
-      async (entry) => await getCollection(entry.name as 'textContent'),
-    ),
-  )
-
   const apiOnly = process.env.PF_API_ONLY === 'true'
 
   if (apiOnly) {
     return []
   }
+  
+  const collections = await Promise.all(
+    content.map(
+      async (entry) => await getCollection(entry.name as 'textContent'),
+    ),
+  )
 
   const flatCol = collections
     .flat()

--- a/src/pages/[section]/[page]/[tab].astro
+++ b/src/pages/[section]/[page]/[tab].astro
@@ -37,6 +37,12 @@ export async function getStaticPaths() {
     ),
   )
 
+  const apiOnly = process.env.PF_API_ONLY === 'true'
+
+  if (apiOnly) {
+    return []
+  }
+
   const flatCol = collections
     .flat()
     .map(({ data, filePath, ...rest }) => ({


### PR DESCRIPTION
Closes #212 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a `--api-only` CLI flag to enable API-only mode that omits standalone content pages while keeping API routes available.
  * Site homepage now shows an API-focused notice with a link to /api when API-only mode is active.
  * 404 responses display a tailored message explaining API-only availability when API-only mode is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->